### PR TITLE
feature: Treat table metadata in mutations as target metadata

### DIFF
--- a/cmd/rendertree/impl/testdata/delete.yaml
+++ b/cmd/rendertree/impl/testdata/delete.yaml
@@ -1,0 +1,81 @@
+metadata:
+    rowType: {}
+    transaction:
+        id: QVB4b0hEQUVodUpGSV9qWTNvU3RYNmdIN0VqeTVodDhCZ2pWYU1CcllHbTl5Q3k5aEE=
+    undeclaredParameters: {}
+stats:
+    queryPlan:
+        planNodes:
+            - childLinks:
+                - childIndex: 1
+              displayName: Apply Mutations
+              executionStats:
+                execution_summary:
+                    num_executions: "1"
+                latency:
+                    total: "0.04"
+                    unit: msecs
+                rows:
+                    total: "0"
+                    unit: rows
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+                operation_type: DELETE
+                table: MutationTest
+            - childLinks:
+                - childIndex: 2
+                - childIndex: 7
+                  type: Split Range
+              displayName: Distributed Union
+              index: 1
+              kind: RELATIONAL
+              metadata:
+                distribution_table: MutationTest
+                execution_method: Row
+                split_ranges_aligned: "false"
+                subquery_cluster_node: "2"
+            - childLinks:
+                - childIndex: 3
+              displayName: Distributed Union
+              index: 2
+              kind: RELATIONAL
+              metadata:
+                call_type: Local
+                execution_method: Row
+                subquery_cluster_node: "3"
+            - childLinks:
+                - childIndex: 4
+                - childIndex: 6
+              displayName: Serialize Result
+              index: 3
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+            - childLinks:
+                - childIndex: 5
+                  variable: PK
+              displayName: Scan
+              index: 4
+              kind: RELATIONAL
+              metadata:
+                Full scan: "true"
+                execution_method: Row
+                scan_method: Automatic
+                scan_target: MutationTest
+                scan_type: TableScan
+            - displayName: Reference
+              index: 5
+              kind: SCALAR
+              shortRepresentation:
+                description: PK
+            - displayName: Reference
+              index: 6
+              kind: SCALAR
+              shortRepresentation:
+                description: $PK
+            - displayName: Constant
+              index: 7
+              kind: SCALAR
+              shortRepresentation:
+                description: "true"

--- a/queryplan.go
+++ b/queryplan.go
@@ -110,13 +110,15 @@ const (
 	ExecutionMethodFormatAngle
 )
 
+// TargetMetadataFormat controls how to render target metadata.
+// target metadata are scan_target, distribution_table, and table.
 type TargetMetadataFormat int64
 
 const (
-	// TargetMetadataFormatRaw prints scan_target and distribution_table metadata as is.
+	// TargetMetadataFormatRaw prints target metadata as is.
 	TargetMetadataFormatRaw TargetMetadataFormat = iota
 
-	// TargetMetadataFormatOn prints scan_target and distribution_table metadata as `on <target>`.
+	// TargetMetadataFormatOn prints target metadata as `on <target>`.
 	TargetMetadataFormatOn
 )
 
@@ -218,12 +220,20 @@ func NodeTitle(node *sppb.PlanNode, opts ...Option) string {
 		case "subquery_cluster_node": // Skip because it is useless
 			continue
 		case "scan_target":
+			if o.targetMetadataFormat != TargetMetadataFormatRaw {
+				continue
+			}
+
 			fields = append(fields, fmt.Sprintf("%s: %s",
 				strings.TrimSuffix(metadataFields["scan_type"].GetStringValue(), "Scan"),
 				v.GetStringValue()))
 			continue
 		case "execution_method":
 			if o.executionMethodFormat != ExecutionMethodFormatRaw {
+				continue
+			}
+		case "distribution_table", "table":
+			if o.targetMetadataFormat != TargetMetadataFormatRaw {
 				continue
 			}
 		}


### PR DESCRIPTION
This PR update `spannerplan.TargetMetadataFormatLabel` and `--target-metadata LABEL` treats `table` metadata(in `Apply Mutation`) as target metadata.
I believe it makes plan representation more consistent.

before

```
$ go run 'github.com/apstndb/spannerplan/cmd/rendertree@v0.1.0' < delete.yaml 
+----+----------------------------------------------------------------------------------+
| ID | Operator                                                                         |
+----+----------------------------------------------------------------------------------+
|  0 | Apply Mutations <Row> (operation_type: DELETE, table: MutationTest)              |
|  1 | +- Distributed Union on MutationTest <Row>                                       |
|  2 |    +- Local Distributed Union <Row>                                              |
|  3 |       +- Serialize Result <Row>                                                  |
|  4 |          +- Table Scan on MutationTest <Row> (Full scan, scan_method: Automatic) |
+----+----------------------------------------------------------------------------------+
```

after

```
$ go run ./cmd/rendertree < delete.yaml                        
+----+----------------------------------------------------------------------------------+
| ID | Operator                                                                         |
+----+----------------------------------------------------------------------------------+
|  0 | Apply Mutations on MutationTest <Row> (operation_type: DELETE)                   |
|  1 | +- Distributed Union on MutationTest <Row>                                       |
|  2 |    +- Local Distributed Union <Row>                                              |
|  3 |       +- Serialize Result <Row>                                                  |
|  4 |          +- Table Scan on MutationTest <Row> (Full scan, scan_method: Automatic) |
+----+----------------------------------------------------------------------------------+
```