### PR TITLE
Implement rendertree --mode=AUTO (default)

### DIFF
--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -41,6 +41,8 @@ $ gcloud spanner databases execute-sql ${DATABASE_ID} --sql="SELECT * FROM Singe
 +----+-------------------------------------------------------+------+-------+---------+
 ```
 
+Note: `--mode=PLAN` and `--mode=PROFILE` can be omitted because the default `--mode=AUTO` can detect whether the input has execution statistics or not.
+
 Rendered stats columns are customizable using `--custom-file`.
 
 ```

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -217,7 +217,7 @@ func parseExplainMode(s string) (explainMode, error) {
 	case "AUTO":
 		return explainModeAuto, nil
 	default:
-		return "", fmt.Errorf("unknown mode: %s", s)
+		return "", fmt.Errorf("invalid input: %s. Must be one of AUTO, PLAN, PROFILE (case-insensitive)", s)
 	}
 }
 
@@ -256,7 +256,7 @@ func run() error {
 
 	parsedMode, err := parseExplainMode(*mode)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid value for -mode flag: %s.  Must be one of AUTO, PLAN, PROFILE.\n", *mode)
+		fmt.Fprintf(os.Stderr, "Invalid value for -mode flag: %v\n", err)
 		flag.Usage()
 		os.Exit(1)
 	}

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -353,3 +353,66 @@ Predicates(identified by ID):
 		})
 	}
 }
+
+func TestShouldRenderWithStats(t *testing.T) {
+	decodeQueryPlan := func(b []byte) (*spannerplan.QueryPlan, error) {
+		stats, _, err := spannerplan.ExtractQueryPlan(b)
+		if err != nil {
+			return nil, err
+		}
+		return spannerplan.New(stats.GetQueryPlan().GetPlanNodes())
+	}
+
+	tests := []struct {
+		desc       string
+		qp         *spannerplan.QueryPlan
+		parsedMode explainMode
+		want       bool
+	}{
+		{
+			"PLAN mode, no stats",
+			lo.Must(decodeQueryPlan(dcaYAML)),
+			explainModePlan,
+			false,
+		},
+		{
+			"PLAN mode, with stats",
+			lo.Must(decodeQueryPlan(dcaProfileYAML)),
+			explainModePlan,
+			false,
+		},
+		{
+			"PROFILE mode, no stats",
+			lo.Must(decodeQueryPlan(dcaYAML)),
+			explainModeProfile,
+			true,
+		},
+		{
+			"PROFILE mode, with stats",
+			lo.Must(decodeQueryPlan(dcaProfileYAML)),
+			explainModeProfile,
+			true,
+		},
+		{
+			"AUTO mode, no stats",
+			lo.Must(decodeQueryPlan(dcaYAML)),
+			explainModeAuto,
+			false,
+		},
+		{
+			"AUTO mode, with stats",
+			lo.Must(decodeQueryPlan(dcaProfileYAML)),
+			explainModeAuto,
+			true,
+		},
+	}
+
+	for _, tcase := range tests {
+		t.Run(tcase.desc, func(t *testing.T) {
+			got := shouldRenderWithStats(tcase.qp, tcase.parsedMode)
+			if got != tcase.want {
+				t.Errorf("shouldRenderWithStats got %v, but want %v", got, tcase.want)
+			}
+		})
+	}
+}

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -16,6 +16,7 @@ import (
 func sliceOf[T any](vs ...T) []T {
 	return vs
 }
+
 func Test_customFileToTableRenderDef(t *testing.T) {
 	yamlContent := `
 - name: ID

--- a/queryplan.go
+++ b/queryplan.go
@@ -281,3 +281,11 @@ type ResolvedChildLink struct {
 	ChildLink *sppb.PlanNode_ChildLink
 	Child     *sppb.PlanNode
 }
+
+func HasStats(nodes []*sppb.PlanNode) bool {
+	if len(nodes) == 0 {
+		return false
+	}
+
+	return nodes[0].ExecutionStats != nil
+}

--- a/queryplan.go
+++ b/queryplan.go
@@ -287,6 +287,7 @@ type ResolvedChildLink struct {
 }
 
 func HasStats(nodes []*sppb.PlanNode) bool {
+	// hasStats returns true only if the first node has ExecutionStats.
 	if len(nodes) == 0 {
 		return false
 	}

--- a/queryplan.go
+++ b/queryplan.go
@@ -34,6 +34,10 @@ func New(planNodes []*sppb.PlanNode) (*QueryPlan, error) {
 	return &QueryPlan{planNodes, parentMap}, nil
 }
 
+func (qp *QueryPlan) HasStats() bool {
+	return HasStats(qp.PlanNodes())
+}
+
 func (qp *QueryPlan) IsFunction(childLink *sppb.PlanNode_ChildLink) bool {
 	// Known predicates are Condition(Filter, Hash Join) or Seek Condition(FilterScan) or Residual Condition(FilterScan, Hash Join) or Split Range(Distributed Union).
 	// Agg(Aggregate) is a Function but not a predicate.

--- a/queryplan_test.go
+++ b/queryplan_test.go
@@ -8,9 +8,6 @@ import (
 )
 
 func TestHasStats(t *testing.T) {
-	type args struct {
-		nodes []*sppb.PlanNode
-	}
 	tests := []struct {
 		name  string
 		input []*sppb.PlanNode

--- a/queryplan_test.go
+++ b/queryplan_test.go
@@ -1,0 +1,42 @@
+package spannerplan
+
+import (
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestHasStats(t *testing.T) {
+	type args struct {
+		nodes []*sppb.PlanNode
+	}
+	tests := []struct {
+		name  string
+		input []*sppb.PlanNode
+		want  bool
+	}{
+		{
+			"has stats",
+			[]*sppb.PlanNode{{ExecutionStats: &structpb.Struct{}}},
+			true,
+		},
+		{
+			"no stats",
+			[]*sppb.PlanNode{{ExecutionStats: nil}},
+			false,
+		},
+		{
+			"empty",
+			nil,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasStats(tt.input); got != tt.want {
+				t.Errorf("HasStats() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements `--mode=AUTO` as the default in rendertree.
This mode detects input query plan has execution stats or not, and choose `--mode=PLAN` or `--mode=PROFILE` automatically.
I believe it improves usability of rendertree.

```
$ rendertree < plan.yaml        
+-----+-------------------------------------------------------------------------------------------+
| ID  | Operator                                                                                  |
+-----+-------------------------------------------------------------------------------------------+
|   0 | Distributed Union on AlbumsByAlbumTitle <Row>                                             |
|  *1 | +- Distributed Cross Apply <Row>                                                          |
|   2 |    +- [Input] Create Batch <Row>                                                          |
|   3 |    |  +- Local Distributed Union <Row>                                                    |
|   4 |    |     +- Compute Struct <Row>                                                          |
|   5 |    |        +- Index Scan on AlbumsByAlbumTitle <Row> (Full scan, scan_method: Automatic) |
|  11 |    +- [Map] Serialize Result <Row>                                                        |
|  12 |       +- Cross Apply <Row>                                                                |
|  13 |          +- [Input] Batch Scan on $v2 <Row> (scan_method: Row)                            |
|  16 |          +- [Map] Local Distributed Union <Row>                                           |
| *17 |             +- Filter Scan <Row> (seekable_key_size: 0)                                   |
|  18 |                +- Index Scan on SongsBySongGenre <Row> (Full scan, scan_method: Row)      |
+-----+-------------------------------------------------------------------------------------------+
Predicates(identified by ID):
  1: Split Range: ($AlbumId = $AlbumId_1)
 17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
```
```
$ rendertree < profile.yaml
+-----+-------------------------------------------------------------------------------------------+------+-------+---------+
| ID  | Operator                                                                                  | Rows | Exec. | Latency |
+-----+-------------------------------------------------------------------------------------------+------+-------+---------+
|   0 | Distributed Union on AlbumsByAlbumTitle <Row>                                             |   33 |     1 | 1.92 ms |
|  *1 | +- Distributed Cross Apply <Row>                                                          |   33 |     1 |  1.9 ms |
|   2 |    +- [Input] Create Batch <Row>                                                          |      |       |         |
|   3 |    |  +- Local Distributed Union <Row>                                                    |    7 |     1 | 0.95 ms |
|   4 |    |     +- Compute Struct <Row>                                                          |    7 |     1 | 0.94 ms |
|   5 |    |        +- Index Scan on AlbumsByAlbumTitle <Row> (Full scan, scan_method: Automatic) |    7 |     1 | 0.93 ms |
|  11 |    +- [Map] Serialize Result <Row>                                                        |   33 |     1 | 0.88 ms |
|  12 |       +- Cross Apply <Row>                                                                |   33 |     1 | 0.87 ms |
|  13 |          +- [Input] Batch Scan on $v2 <Row> (scan_method: Row)                            |    7 |     1 | 0.01 ms |
|  16 |          +- [Map] Local Distributed Union <Row>                                           |   33 |     7 | 0.85 ms |
| *17 |             +- Filter Scan <Row> (seekable_key_size: 0)                                   |      |       |         |
|  18 |                +- Index Scan on SongsBySongGenre <Row> (Full scan, scan_method: Row)      |   33 |     7 | 0.84 ms |
+-----+-------------------------------------------------------------------------------------------+------+-------+---------+
Predicates(identified by ID):
  1: Split Range: ($AlbumId = $AlbumId_1)
 17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
$ 
```