### PR TITLE
refactor: isolate rendertree CLI runner

### DIFF
--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -305,6 +305,9 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	var custom stringList
 	flagSet.Var(&custom, "custom", "")
 	if err := flagSet.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
 		return &usageError{err: err}
 	}
 

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -326,7 +326,9 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 
 	printMode, err := parsePrintMode(*printModeStr)
 	if err != nil {
-		return err
+		_, _ = fmt.Fprintf(stderr, "Invalid value for -print flag: %v\n", err)
+		flagSet.Usage()
+		return &usageError{err: err}
 	}
 
 	parsedMode, err := parseExplainMode(*mode)

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -28,9 +29,25 @@ import (
 // Main is the entry point of this command.
 // It is also used by github.com/apstndb/spannerplanviz/cmd/rendertree
 func Main() {
-	if err := run(); err != nil {
+	if err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
+		var usageErr *usageError
+		if errors.As(err, &usageErr) {
+			os.Exit(1)
+		}
 		log.Fatal(err)
 	}
+}
+
+type usageError struct {
+	err error
+}
+
+func (e *usageError) Error() string {
+	return e.err.Error()
+}
+
+func (e *usageError) Unwrap() error {
+	return e.err
 }
 
 type tableRenderDef struct {
@@ -269,31 +286,36 @@ func parseExplainMode(s string) (explainMode, error) {
 	}
 }
 
-func run() error {
-	customFile := flag.String("custom-file", "", "")
-	mode := flag.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
-	printModeStr := flag.String("print", "predicates", "print node parameters(EXPERIMENTAL)")
-	disallowUnknownStats := flag.Bool("disallow-unknown-stats", false, "error on unknown stats field")
-	executionMethod := flag.String("execution-method", "angle", "Format execution method metadata: 'angle' or 'raw' (default: angle)")
-	targetMetadata := flag.String("target-metadata", "on", "Format target metadata: 'on' or 'raw' (default: on)")
-	fullscan := flag.String("full-scan", "", "Deprecated alias for --known-flag.")
-	knownFlag := flag.String("known-flag", "", "Format known flags: 'label' or 'raw' (default: label)")
-	compact := flag.Bool("compact", false, "Enable compact format")
-	inlineStats := flag.Bool("inline-stats", false, "Enable inline stats")
-	wrapWidth := flag.Int("wrap-width", 0, "Number of characters at which to wrap the Operator column content. 0 means no wrapping.")
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	flagSet := flag.NewFlagSet("rendertree", flag.ContinueOnError)
+	flagSet.SetOutput(stderr)
+
+	customFile := flagSet.String("custom-file", "", "")
+	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
+	printModeStr := flagSet.String("print", "predicates", "print node parameters(EXPERIMENTAL)")
+	disallowUnknownStats := flagSet.Bool("disallow-unknown-stats", false, "error on unknown stats field")
+	executionMethod := flagSet.String("execution-method", "angle", "Format execution method metadata: 'angle' or 'raw' (default: angle)")
+	targetMetadata := flagSet.String("target-metadata", "on", "Format target metadata: 'on' or 'raw' (default: on)")
+	fullscan := flagSet.String("full-scan", "", "Deprecated alias for --known-flag.")
+	knownFlag := flagSet.String("known-flag", "", "Format known flags: 'label' or 'raw' (default: label)")
+	compact := flagSet.Bool("compact", false, "Enable compact format")
+	inlineStats := flagSet.Bool("inline-stats", false, "Enable inline stats")
+	wrapWidth := flagSet.Int("wrap-width", 0, "Number of characters at which to wrap the Operator column content. 0 means no wrapping.")
 
 	var custom stringList
-	flag.Var(&custom, "custom", "")
-	flag.Parse()
+	flagSet.Var(&custom, "custom", "")
+	if err := flagSet.Parse(args); err != nil {
+		return &usageError{err: err}
+	}
 
 	if *fullscan != "" {
 		if *knownFlag != "" {
-			fmt.Fprintln(os.Stderr, "--full-scan and --known-flag are mutually exclusive.")
-			flag.Usage()
-			os.Exit(1)
+			_, _ = fmt.Fprintln(stderr, "--full-scan and --known-flag are mutually exclusive.")
+			flagSet.Usage()
+			return &usageError{err: errors.New("full-scan and known-flag are mutually exclusive")}
 		}
 
-		fmt.Fprintln(os.Stderr, "--full-scan is deprecated. you must migrate to --known-flag.")
+		_, _ = fmt.Fprintln(stderr, "--full-scan is deprecated. you must migrate to --known-flag.")
 
 		*knownFlag = *fullscan
 	}
@@ -305,9 +327,9 @@ func run() error {
 
 	parsedMode, err := parseExplainMode(*mode)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid value for -mode flag: %v\n", err)
-		flag.Usage()
-		os.Exit(1)
+		_, _ = fmt.Fprintf(stderr, "Invalid value for -mode flag: %v\n", err)
+		flagSet.Usage()
+		return &usageError{err: err}
 	}
 
 	var opts []plantree.Option
@@ -323,9 +345,9 @@ func run() error {
 	if *executionMethod != "" {
 		em, err = spannerplan.ParseExecutionMethodFormat(*executionMethod)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid value for -execution-method flag: %v.\n", err)
-			flag.Usage()
-			os.Exit(1)
+			_, _ = fmt.Fprintf(stderr, "Invalid value for -execution-method flag: %v.\n", err)
+			flagSet.Usage()
+			return &usageError{err: err}
 		}
 	}
 	opts = append(opts, plantree.WithQueryPlanOptions(spannerplan.WithExecutionMethodFormat(em)))
@@ -334,9 +356,9 @@ func run() error {
 	if *targetMetadata != "" {
 		tm, err = spannerplan.ParseTargetMetadataFormat(*targetMetadata)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid value for -target-metadata flag: %v.\n", err)
-			flag.Usage()
-			os.Exit(1)
+			_, _ = fmt.Fprintf(stderr, "Invalid value for -target-metadata flag: %v.\n", err)
+			flagSet.Usage()
+			return &usageError{err: err}
 		}
 	}
 	opts = append(opts, plantree.WithQueryPlanOptions(spannerplan.WithTargetMetadataFormat(tm)))
@@ -345,9 +367,9 @@ func run() error {
 	if *knownFlag != "" {
 		kf, err = spannerplan.ParseKnownFlagFormat(*knownFlag)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid value for -known-flag flag: %v.\n", err)
-			flag.Usage()
-			os.Exit(1)
+			_, _ = fmt.Fprintf(stderr, "Invalid value for -known-flag flag: %v.\n", err)
+			flagSet.Usage()
+			return &usageError{err: err}
 		}
 	}
 	opts = append(opts, plantree.WithQueryPlanOptions(spannerplan.WithKnownFlagFormat(kf)))
@@ -356,7 +378,7 @@ func run() error {
 		opts = append(opts, plantree.WithWrapWidth(*wrapWidth))
 	}
 
-	b, err := io.ReadAll(os.Stdin)
+	b, err := io.ReadAll(stdin)
 	if err != nil {
 		return err
 	}
@@ -397,7 +419,7 @@ func run() error {
 		return err
 	}
 
-	_, err = os.Stdout.WriteString(s)
+	_, err = io.WriteString(stdout, s)
 	return err
 }
 

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -32,7 +32,7 @@ func Main() {
 	if err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
 		var usageErr *usageError
 		if errors.As(err, &usageErr) {
-			os.Exit(1)
+			os.Exit(2)
 		}
 		log.Fatal(err)
 	}
@@ -290,7 +290,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	flagSet := flag.NewFlagSet("rendertree", flag.ContinueOnError)
 	flagSet.SetOutput(stderr)
 
-	customFile := flagSet.String("custom-file", "", "")
+	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file")
 	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
 	printModeStr := flagSet.String("print", "predicates", "print node parameters(EXPERIMENTAL)")
 	disallowUnknownStats := flagSet.Bool("disallow-unknown-stats", false, "error on unknown stats field")
@@ -303,7 +303,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	wrapWidth := flagSet.Int("wrap-width", 0, "Number of characters at which to wrap the Operator column content. 0 means no wrapping.")
 
 	var custom stringList
-	flagSet.Var(&custom, "custom", "")
+	flagSet.Var(&custom, "custom", "Add a custom table column definition in NAME:TEMPLATE[:ALIGNMENT] form")
 	if err := flagSet.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -313,12 +313,13 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 
 	if *fullscan != "" {
 		if *knownFlag != "" {
-			_, _ = fmt.Fprintln(stderr, "--full-scan and --known-flag are mutually exclusive.")
+			const msg = "--full-scan and --known-flag are mutually exclusive"
+			_, _ = fmt.Fprintln(stderr, msg)
 			flagSet.Usage()
-			return &usageError{err: errors.New("full-scan and known-flag are mutually exclusive")}
+			return &usageError{err: errors.New(msg)}
 		}
 
-		_, _ = fmt.Fprintln(stderr, "--full-scan is deprecated. you must migrate to --known-flag.")
+		_, _ = fmt.Fprintln(stderr, "--full-scan is deprecated. You must migrate to --known-flag.")
 
 		*knownFlag = *fullscan
 	}
@@ -370,7 +371,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	if *knownFlag != "" {
 		kf, err = spannerplan.ParseKnownFlagFormat(*knownFlag)
 		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "Invalid value for -known-flag flag: %v.\n", err)
+			_, _ = fmt.Fprintf(stderr, "Invalid value for -known-flag: %v.\n", err)
 			flagSet.Usage()
 			return &usageError{err: err}
 		}

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -508,3 +508,19 @@ func TestRun_DeprecatedFullScanAlias(t *testing.T) {
 		t.Fatalf("stdout = %q, want rendered table output", stdout.String())
 	}
 }
+
+func TestRun_HelpReturnsNil(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := run([]string{"-h"}, strings.NewReader(""), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, want nil", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "-mode") {
+		t.Fatalf("stderr = %q, want usage output", stderr.String())
+	}
+}

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -464,6 +464,20 @@ func TestRun_UsageErrors(t *testing.T) {
 			},
 		},
 		{
+			name:        "invalid print",
+			args:        []string{"-print", "broken"},
+			wantErrText: "unknown PrintMode: broken",
+			postCheck: func(t *testing.T, stderr string, err error) {
+				t.Helper()
+				if !strings.Contains(stderr, "Invalid value for -print flag:") {
+					t.Fatalf("stderr = %q, want invalid print message", stderr)
+				}
+				if !strings.Contains(stderr, "Usage of rendertree:") {
+					t.Fatalf("stderr = %q, want usage output", stderr)
+				}
+			},
+		},
+		{
 			name:        "unknown flag",
 			args:        []string{"-unknown"},
 			wantErrText: "flag provided but not defined: -unknown",

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -450,19 +450,43 @@ func TestRun_UsageErrors(t *testing.T) {
 		name        string
 		args        []string
 		wantErrText string
-		wantStderr  string
+		postCheck   func(t *testing.T, stderr string, err error)
 	}{
 		{
 			name:        "invalid mode",
 			args:        []string{"-mode", "broken"},
 			wantErrText: "invalid input: broken",
-			wantStderr:  "Invalid value for -mode flag:",
+			postCheck: func(t *testing.T, stderr string, err error) {
+				t.Helper()
+				if !strings.Contains(stderr, "Invalid value for -mode flag:") {
+					t.Fatalf("stderr = %q, want invalid mode message", stderr)
+				}
+			},
+		},
+		{
+			name:        "unknown flag",
+			args:        []string{"-unknown"},
+			wantErrText: "flag provided but not defined: -unknown",
+			postCheck: func(t *testing.T, stderr string, err error) {
+				t.Helper()
+				if !strings.Contains(stderr, "flag provided but not defined: -unknown") {
+					t.Fatalf("stderr = %q, want unknown flag message", stderr)
+				}
+				if !strings.Contains(stderr, "Usage of rendertree:") {
+					t.Fatalf("stderr = %q, want usage output", stderr)
+				}
+			},
 		},
 		{
 			name:        "full-scan and known-flag are mutually exclusive",
 			args:        []string{"-full-scan", "raw", "-known-flag", "label"},
 			wantErrText: "full-scan and known-flag are mutually exclusive",
-			wantStderr:  "--full-scan and --known-flag are mutually exclusive.",
+			postCheck: func(t *testing.T, stderr string, err error) {
+				t.Helper()
+				if !strings.Contains(stderr, "--full-scan and --known-flag are mutually exclusive.") {
+					t.Fatalf("stderr = %q, want mutual exclusion message", stderr)
+				}
+			},
 		},
 	}
 
@@ -483,8 +507,8 @@ func TestRun_UsageErrors(t *testing.T) {
 			if !strings.Contains(err.Error(), tt.wantErrText) {
 				t.Fatalf("run() error = %q, want substring %q", err.Error(), tt.wantErrText)
 			}
-			if !strings.Contains(stderr.String(), tt.wantStderr) {
-				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tt.wantStderr)
+			if tt.postCheck != nil {
+				tt.postCheck(t, stderr.String(), err)
 			}
 			if stdout.Len() != 0 {
 				t.Fatalf("stdout = %q, want empty", stdout.String())

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -1,7 +1,10 @@
 package impl
 
 import (
+	"bytes"
 	_ "embed"
+	"errors"
+	"strings"
 	"testing"
 
 	heredoc "github.com/MakeNowJust/heredoc/v2"
@@ -439,5 +442,69 @@ func TestShouldRenderWithStats(t *testing.T) {
 				t.Errorf("shouldRenderWithStats got %v, but want %v", got, tcase.want)
 			}
 		})
+	}
+}
+
+func TestRun_UsageErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantErrText string
+		wantStderr  string
+	}{
+		{
+			name:        "invalid mode",
+			args:        []string{"-mode", "broken"},
+			wantErrText: "invalid input: broken",
+			wantStderr:  "Invalid value for -mode flag:",
+		},
+		{
+			name:        "full-scan and known-flag are mutually exclusive",
+			args:        []string{"-full-scan", "raw", "-known-flag", "label"},
+			wantErrText: "full-scan and known-flag are mutually exclusive",
+			wantStderr:  "--full-scan and --known-flag are mutually exclusive.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			err := run(tt.args, strings.NewReader(""), &stdout, &stderr)
+			if err == nil {
+				t.Fatal("run() error = nil, want non-nil")
+			}
+
+			var usageErr *usageError
+			if !errors.As(err, &usageErr) {
+				t.Fatalf("run() error = %T, want *usageError", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrText) {
+				t.Fatalf("run() error = %q, want substring %q", err.Error(), tt.wantErrText)
+			}
+			if !strings.Contains(stderr.String(), tt.wantStderr) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tt.wantStderr)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRun_DeprecatedFullScanAlias(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := run([]string{"-full-scan", "label", "-mode", "plan"}, bytes.NewReader(deleteYAML), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if !strings.Contains(stderr.String(), "--full-scan is deprecated. you must migrate to --known-flag.") {
+		t.Fatalf("stderr = %q, want deprecation warning", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Apply Mutations on MutationTest <Row>") {
+		t.Fatalf("stdout = %q, want rendered table output", stdout.String())
 	}
 }

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -480,10 +480,10 @@ func TestRun_UsageErrors(t *testing.T) {
 		{
 			name:        "full-scan and known-flag are mutually exclusive",
 			args:        []string{"-full-scan", "raw", "-known-flag", "label"},
-			wantErrText: "full-scan and known-flag are mutually exclusive",
+			wantErrText: "--full-scan and --known-flag are mutually exclusive",
 			postCheck: func(t *testing.T, stderr string, err error) {
 				t.Helper()
-				if !strings.Contains(stderr, "--full-scan and --known-flag are mutually exclusive.") {
+				if !strings.Contains(stderr, "--full-scan and --known-flag are mutually exclusive") {
 					t.Fatalf("stderr = %q, want mutual exclusion message", stderr)
 				}
 			},
@@ -525,7 +525,7 @@ func TestRun_DeprecatedFullScanAlias(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run() error = %v", err)
 	}
-	if !strings.Contains(stderr.String(), "--full-scan is deprecated. you must migrate to --known-flag.") {
+	if !strings.Contains(stderr.String(), "--full-scan is deprecated. You must migrate to --known-flag.") {
 		t.Fatalf("stderr = %q, want deprecation warning", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Apply Mutations on MutationTest <Row>") {


### PR DESCRIPTION
## Summary
- move `cmd/rendertree` off global `flag` state by using a local `flag.FlagSet`
- refactor `run` to accept `args`, `stdin`, `stdout`, and `stderr` explicitly
- keep `Main()` as the process boundary and make usage-style failures return a dedicated error type instead of calling `os.Exit` from the middle of the implementation
- add CLI tests for invalid flag handling and the deprecated `--full-scan` alias path

## Verification
- `go test ./...`
- `golangci-lint run --timeout=5m`
- Added coverage for invalid flag handling and deprecated `--full-scan` alias behavior in `cmd/rendertree/impl`
