### PR TITLE
fix: reject mixed custom flags

### DIFF
--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -43,7 +43,7 @@ $ gcloud spanner databases execute-sql ${DATABASE_ID} --sql="SELECT * FROM Singe
 
 Note: `--mode=PLAN` and `--mode=PROFILE` can be omitted because the default `--mode=AUTO` can detect whether the input has execution statistics or not.
 
-Rendered stats columns are customizable using `--custom-file`.
+Rendered stats columns are customizable using `--custom-file`. `--custom-file` and `--custom` are mutually exclusive.
 
 ```
 $ cat custom.yaml
@@ -144,7 +144,7 @@ Predicates(identified by ID):
  34: Seek Condition: (($SingerId' = $batched_SingerId) AND ($AlbumId' = $batched_AlbumId) AND ($TrackId' = $batched_TrackId))
 ```
 
-You can also use `--custom=<name>:<template>[:<align>[:<inline_type>]]`.
+You can also use `--custom=<name>:<template>[:<align>[:<inline_type>]]`. `--custom` and `--custom-file` cannot be used together.
 
 ```
 $ cat distributed_cross_apply_profile.yaml | rendertree --custom "ID:{{.FormatID}}:RIGHT,Operator:{{.Text}},CPU Time:{{.ExecutionStats.CpuTime | secsToS}},remote_calls:{{.ExecutionStats.RemoteCalls.Total}}::ALWAYS" 

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -303,7 +303,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	wrapWidth := flagSet.Int("wrap-width", 0, "Number of characters at which to wrap the Operator column content. 0 means no wrapping.")
 
 	var custom stringList
-	flagSet.Var(&custom, "custom", "Add a custom table column definition in NAME:TEMPLATE[:ALIGNMENT] form (mutually exclusive with --custom-file)")
+	flagSet.Var(&custom, "custom", "Add a custom table column definition in NAME:TEMPLATE[:ALIGNMENT[:INLINE_TYPE]] form (mutually exclusive with --custom-file)")
 	if err := flagSet.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -290,7 +290,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	flagSet := flag.NewFlagSet("rendertree", flag.ContinueOnError)
 	flagSet.SetOutput(stderr)
 
-	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file")
+	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file (mutually exclusive with --custom)")
 	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
 	printModeStr := flagSet.String("print", "predicates", "print node parameters(EXPERIMENTAL)")
 	disallowUnknownStats := flagSet.Bool("disallow-unknown-stats", false, "error on unknown stats field")
@@ -303,7 +303,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	wrapWidth := flagSet.Int("wrap-width", 0, "Number of characters at which to wrap the Operator column content. 0 means no wrapping.")
 
 	var custom stringList
-	flagSet.Var(&custom, "custom", "Add a custom table column definition in NAME:TEMPLATE[:ALIGNMENT] form")
+	flagSet.Var(&custom, "custom", "Add a custom table column definition in NAME:TEMPLATE[:ALIGNMENT] form (mutually exclusive with --custom-file)")
 	if err := flagSet.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -322,6 +322,13 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		_, _ = fmt.Fprintln(stderr, "--full-scan is deprecated. You must migrate to --known-flag.")
 
 		*knownFlag = *fullscan
+	}
+
+	if len(custom) > 0 && *customFile != "" {
+		const msg = "--custom and --custom-file are mutually exclusive"
+		_, _ = fmt.Fprintln(stderr, msg)
+		flagSet.Usage()
+		return &usageError{err: errors.New(msg)}
 	}
 
 	printMode, err := parsePrintMode(*printModeStr)

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -311,6 +311,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return &usageError{err: err}
 	}
 
+	// These are semantic flag-combination checks that run after Parse succeeds.
+	// flag.ContinueOnError only covers parse-time failures, so we still print usage here.
 	if *fullscan != "" {
 		if *knownFlag != "" {
 			const msg = "--full-scan and --known-flag are mutually exclusive"

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -502,6 +502,17 @@ func TestRun_UsageErrors(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:        "custom and custom-file are mutually exclusive",
+			args:        []string{"-custom", "ID:{{.FormatID}}", "-custom-file", "custom.yaml"},
+			wantErrText: "--custom and --custom-file are mutually exclusive",
+			postCheck: func(t *testing.T, stderr string, err error) {
+				t.Helper()
+				if !strings.Contains(stderr, "--custom and --custom-file are mutually exclusive") {
+					t.Fatalf("stderr = %q, want mutual exclusion message", stderr)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- reject `--custom` and `--custom-file` when used together
- cover the new usage error in CLI tests
- document the mutual exclusion in the rendertree README

Closes #13