### PR TITLE
feat: add opt-in hanging indent wrapping

### DIFF
--- a/internal/treerender/treerender.go
+++ b/internal/treerender/treerender.go
@@ -12,8 +12,9 @@ type Node struct {
 }
 
 type Row struct {
-	// TreePart is the tree prefix for this node: one line of ASCII tree drawing per line of NodeText,
-	// joined with newlines (same structure as strings.Split(NodeText, "\n")).
+	// TreePart is everything rendered before NodeText on each visual line: the ASCII tree drawing
+	// plus any continuation padding added by the renderer (for example, hanging-indent spacing).
+	// It is joined with newlines using the same line structure as strings.Split(NodeText, "\n").
 	TreePart string
 	NodeText string
 }

--- a/internal/treerender/treerender.go
+++ b/internal/treerender/treerender.go
@@ -18,6 +18,13 @@ type Row struct {
 	NodeText string
 }
 
+type ContinuationIndent int
+
+const (
+	ContinuationIndentTree ContinuationIndent = iota
+	ContinuationIndentAnchor
+)
+
 type Style struct {
 	EdgeLink      string
 	EdgeMid       string
@@ -90,8 +97,25 @@ func Render(root *Node, style Style) []Row {
 
 // RenderTree walks an existing tree without copying it into [Node], using the supplied accessors.
 func RenderTree[T any](root *T, style Style, getText func(*T) string, getChildren func(*T) []*T) []Row {
+	return RenderTreeWithOptions(root, style, getText, getChildren, nil, 0, nil, ContinuationIndentTree)
+}
+
+// RenderTreeWithOptions renders a tree with optional wrapping and continuation-indent behavior.
+func RenderTreeWithOptions[T any](
+	root *T,
+	style Style,
+	getText func(*T) string,
+	getChildren func(*T) []*T,
+	getContinuationAnchor func(*T) string,
+	wrapWidth int,
+	wrapCondition *tabwrap.Condition,
+	continuationIndent ContinuationIndent,
+) []Row {
 	if root == nil {
 		return nil
+	}
+	if wrapCondition == nil {
+		wrapCondition = tabwrap.NewCondition()
 	}
 
 	sw := newStyleWidths(style)
@@ -102,10 +126,11 @@ func RenderTree[T any](root *T, style Style, getText func(*T) string, getChildre
 			return
 		}
 		text := getText(node)
-		rows = append(rows, Row{
-			TreePart: strings.Join(prefixLinesFromAncestor(ancestorPrefix, text, isLast, isRoot, sw), "\n"),
-			NodeText: text,
-		})
+		anchor := ""
+		if getContinuationAnchor != nil {
+			anchor = getContinuationAnchor(node)
+		}
+		rows = append(rows, renderRow(ancestorPrefix, text, anchor, isLast, isRoot, sw, wrapWidth, wrapCondition, continuationIndent))
 
 		next := ancestorPrefix
 		if !isRoot {
@@ -129,6 +154,98 @@ func RenderTree[T any](root *T, style Style, getText func(*T) string, getChildre
 
 	walk(root, "", true, true)
 	return rows
+}
+
+func renderRow(
+	ancestorPrefix, text, anchor string,
+	isLast, isRoot bool,
+	sw styleWidths,
+	wrapWidth int,
+	wrapCondition *tabwrap.Condition,
+	continuationIndent ContinuationIndent,
+) Row {
+	if wrapWidth <= 0 {
+		return Row{
+			TreePart: strings.Join(prefixLinesFromAncestor(ancestorPrefix, text, isLast, isRoot, sw), "\n"),
+			NodeText: text,
+		}
+	}
+
+	firstPrefix, continuationPrefix := rowPrefixes(ancestorPrefix, isLast, isRoot, sw)
+	treeLines, nodeLines := wrapRowLines(text, anchor, firstPrefix, continuationPrefix, wrapWidth, wrapCondition, continuationIndent)
+	return Row{
+		TreePart: strings.Join(treeLines, "\n"),
+		NodeText: strings.Join(nodeLines, "\n"),
+	}
+}
+
+func rowPrefixes(ancestorPrefix string, isLast, isRoot bool, sw styleWidths) (first, continuation string) {
+	if isRoot {
+		return "", ""
+	}
+	first = ancestorPrefix + edgeForRow(isLast, sw.style) + sw.style.EdgeSeparator
+	return first, ancestorPrefix + sw.continuationSegment(isLast)
+}
+
+func wrapRowLines(
+	text, anchor, firstPrefix, continuationPrefix string,
+	wrapWidth int,
+	wrapCondition *tabwrap.Condition,
+	continuationIndent ContinuationIndent,
+) (treeLines, nodeLines []string) {
+	anchorWidth := 0
+	if continuationIndent == ContinuationIndentAnchor && anchor != "" && strings.HasPrefix(text, anchor) {
+		anchorWidth = wrapCondition.StringWidth(anchor)
+		text = strings.TrimPrefix(text, anchor)
+	} else {
+		anchor = ""
+	}
+
+	firstBudget := max(1, wrapWidth-wrapCondition.StringWidth(firstPrefix)-anchorWidth)
+	continuationBudget := max(1, wrapWidth-wrapCondition.StringWidth(continuationPrefix)-anchorWidth)
+	nodeLines = wrapChunks(text, firstBudget, continuationBudget, wrapCondition)
+	if len(nodeLines) == 0 {
+		nodeLines = []string{""}
+	}
+	nodeLines[0] = anchor + nodeLines[0]
+
+	treeLines = make([]string, len(nodeLines))
+	treeLines[0] = firstPrefix
+	continuationTree := continuationPrefix
+	if anchorWidth > 0 {
+		continuationTree += strings.Repeat(" ", anchorWidth)
+	}
+	for i := 1; i < len(treeLines); i++ {
+		treeLines[i] = continuationTree
+	}
+	return treeLines, nodeLines
+}
+
+func wrapChunks(text string, firstBudget, continuationBudget int, wrapCondition *tabwrap.Condition) []string {
+	rawLines := strings.Split(text, "\n")
+	lines := make([]string, 0, len(rawLines))
+	budget := firstBudget
+	for _, rawLine := range rawLines {
+		if rawLine == "" {
+			lines = append(lines, "")
+			budget = continuationBudget
+			continue
+		}
+		for rawLine != "" {
+			rawChunk := wrapCondition.Truncate(rawLine, budget, "")
+			if rawChunk == "" {
+				rawChunk = rawLine[:1]
+			}
+			chunk := rawChunk
+			if wrapCondition.TrimTrailingSpace {
+				chunk = strings.TrimRight(chunk, " \t")
+			}
+			lines = append(lines, chunk)
+			rawLine = strings.TrimPrefix(rawLine, rawChunk)
+			budget = continuationBudget
+		}
+	}
+	return lines
 }
 
 func prefixLinesFromAncestor(ancestorPrefix, text string, isLast, isRoot bool, sw styleWidths) []string {

--- a/internal/treerender/treerender.go
+++ b/internal/treerender/treerender.go
@@ -1,6 +1,7 @@
 package treerender
 
 import (
+	"fmt"
 	"strings"
 	"unicode/utf8"
 
@@ -32,6 +33,14 @@ const (
 	ContinuationIndentTree ContinuationIndent = iota
 	ContinuationIndentAnchor
 )
+
+// RenderOptions configures the optional wrapping behavior of [RenderTreeWithOptions].
+type RenderOptions[T any] struct {
+	GetContinuationAnchor func(*T) string
+	WrapWidth             int
+	WrapCondition         *tabwrap.Condition
+	ContinuationIndent    ContinuationIndent
+}
 
 type Style struct {
 	EdgeLink      string
@@ -105,24 +114,60 @@ func Render(root *Node, style Style) []Row {
 
 // RenderTree walks an existing tree without copying it into [Node], using the supplied accessors.
 func RenderTree[T any](root *T, style Style, getText func(*T) string, getChildren func(*T) []*T) []Row {
-	return RenderTreeWithOptions(root, style, getText, getChildren, nil, 0, nil, ContinuationIndentTree)
+	return renderTree(root, style, getText, getChildren, defaultRenderOptions[T]())
 }
 
 // RenderTreeWithOptions renders a tree with optional wrapping and continuation-indent behavior.
+// It returns an error if opts contains an invalid [ContinuationIndent].
 func RenderTreeWithOptions[T any](
 	root *T,
 	style Style,
 	getText func(*T) string,
 	getChildren func(*T) []*T,
-	getContinuationAnchor func(*T) string,
-	wrapWidth int,
-	wrapCondition *tabwrap.Condition,
-	continuationIndent ContinuationIndent,
-) []Row {
-	validateContinuationIndent(continuationIndent)
-	if wrapCondition == nil {
-		wrapCondition = defaultWrapCondition
+	opts RenderOptions[T],
+) ([]Row, error) {
+	resolved, err := resolveRenderOptions(opts)
+	if err != nil {
+		return nil, err
 	}
+	return renderTree(root, style, getText, getChildren, resolved), nil
+}
+
+type resolvedRenderOptions[T any] struct {
+	getContinuationAnchor func(*T) string
+	wrapWidth             int
+	wrapCondition         *tabwrap.Condition
+	continuationIndent    ContinuationIndent
+}
+
+func defaultRenderOptions[T any]() resolvedRenderOptions[T] {
+	return resolvedRenderOptions[T]{
+		wrapCondition:      defaultWrapCondition,
+		continuationIndent: ContinuationIndentTree,
+	}
+}
+
+func resolveRenderOptions[T any](opts RenderOptions[T]) (resolvedRenderOptions[T], error) {
+	resolved := defaultRenderOptions[T]()
+	resolved.getContinuationAnchor = opts.GetContinuationAnchor
+	resolved.wrapWidth = opts.WrapWidth
+	if opts.WrapCondition != nil {
+		resolved.wrapCondition = opts.WrapCondition
+	}
+	if err := validateContinuationIndent(opts.ContinuationIndent); err != nil {
+		return resolvedRenderOptions[T]{}, err
+	}
+	resolved.continuationIndent = opts.ContinuationIndent
+	return resolved, nil
+}
+
+func renderTree[T any](
+	root *T,
+	style Style,
+	getText func(*T) string,
+	getChildren func(*T) []*T,
+	opts resolvedRenderOptions[T],
+) []Row {
 	if root == nil {
 		return nil
 	}
@@ -136,10 +181,10 @@ func RenderTreeWithOptions[T any](
 		}
 		text := getText(node)
 		anchor := ""
-		if wrapWidth > 0 && continuationIndent == ContinuationIndentAnchor && getContinuationAnchor != nil {
-			anchor = getContinuationAnchor(node)
+		if opts.wrapWidth > 0 && opts.continuationIndent == ContinuationIndentAnchor && opts.getContinuationAnchor != nil {
+			anchor = opts.getContinuationAnchor(node)
 		}
-		rows = append(rows, renderRow(ancestorPrefix, text, anchor, isLast, isRoot, sw, wrapWidth, wrapCondition, continuationIndent))
+		rows = append(rows, renderRow(ancestorPrefix, text, anchor, isLast, isRoot, sw, opts.wrapWidth, opts.wrapCondition, opts.continuationIndent))
 
 		next := ancestorPrefix
 		if !isRoot {
@@ -203,18 +248,11 @@ func wrapRowLines(
 	continuationIndent ContinuationIndent,
 ) (treeLines, nodeLines []string) {
 	anchorWidth := 0
-	switch continuationIndent {
-	case ContinuationIndentTree:
+	if continuationIndent == ContinuationIndentAnchor && anchor != "" && strings.HasPrefix(text, anchor) {
+		anchorWidth = wrapCondition.StringWidth(anchor)
+		text = strings.TrimPrefix(text, anchor)
+	} else {
 		anchor = ""
-	case ContinuationIndentAnchor:
-		if anchor != "" && strings.HasPrefix(text, anchor) {
-			anchorWidth = wrapCondition.StringWidth(anchor)
-			text = strings.TrimPrefix(text, anchor)
-		} else {
-			anchor = ""
-		}
-	default:
-		panic("treerender: invalid ContinuationIndent")
 	}
 
 	firstBudget := max(1, wrapWidth-wrapCondition.StringWidth(firstPrefix)-anchorWidth)
@@ -237,12 +275,12 @@ func wrapRowLines(
 	return treeLines, nodeLines
 }
 
-func validateContinuationIndent(continuationIndent ContinuationIndent) {
+func validateContinuationIndent(continuationIndent ContinuationIndent) error {
 	switch continuationIndent {
 	case ContinuationIndentTree, ContinuationIndentAnchor:
-		return
+		return nil
 	default:
-		panic("treerender: invalid ContinuationIndent")
+		return fmt.Errorf("invalid ContinuationIndent: %d", continuationIndent)
 	}
 }
 

--- a/internal/treerender/treerender.go
+++ b/internal/treerender/treerender.go
@@ -7,7 +7,11 @@ import (
 	"github.com/apstndb/go-tabwrap"
 )
 
-var defaultWrapCondition = tabwrap.NewCondition()
+var defaultWrapCondition = func() *tabwrap.Condition {
+	cond := tabwrap.NewCondition()
+	cond.TrimTrailingSpace = true
+	return cond
+}()
 
 type Node struct {
 	Text     string

--- a/internal/treerender/treerender.go
+++ b/internal/treerender/treerender.go
@@ -135,7 +135,7 @@ func RenderTreeWithOptions[T any](
 		}
 		text := getText(node)
 		anchor := ""
-		if getContinuationAnchor != nil {
+		if wrapWidth > 0 && continuationIndent == ContinuationIndentAnchor && getContinuationAnchor != nil {
 			anchor = getContinuationAnchor(node)
 		}
 		rows = append(rows, renderRow(ancestorPrefix, text, anchor, isLast, isRoot, sw, wrapWidth, wrapCondition, continuationIndent))
@@ -202,11 +202,18 @@ func wrapRowLines(
 	continuationIndent ContinuationIndent,
 ) (treeLines, nodeLines []string) {
 	anchorWidth := 0
-	if continuationIndent == ContinuationIndentAnchor && anchor != "" && strings.HasPrefix(text, anchor) {
-		anchorWidth = wrapCondition.StringWidth(anchor)
-		text = strings.TrimPrefix(text, anchor)
-	} else {
+	switch continuationIndent {
+	case ContinuationIndentTree:
 		anchor = ""
+	case ContinuationIndentAnchor:
+		if anchor != "" && strings.HasPrefix(text, anchor) {
+			anchorWidth = wrapCondition.StringWidth(anchor)
+			text = strings.TrimPrefix(text, anchor)
+		} else {
+			anchor = ""
+		}
+	default:
+		panic("treerender: invalid ContinuationIndent")
 	}
 
 	firstBudget := max(1, wrapWidth-wrapCondition.StringWidth(firstPrefix)-anchorWidth)

--- a/internal/treerender/treerender.go
+++ b/internal/treerender/treerender.go
@@ -122,6 +122,7 @@ func RenderTreeWithOptions[T any](
 	if root == nil {
 		return nil
 	}
+	validateContinuationIndent(continuationIndent)
 	if wrapCondition == nil {
 		wrapCondition = defaultWrapCondition
 	}
@@ -234,6 +235,15 @@ func wrapRowLines(
 		treeLines[i] = continuationTree
 	}
 	return treeLines, nodeLines
+}
+
+func validateContinuationIndent(continuationIndent ContinuationIndent) {
+	switch continuationIndent {
+	case ContinuationIndentTree, ContinuationIndentAnchor:
+		return
+	default:
+		panic("treerender: invalid ContinuationIndent")
+	}
 }
 
 func wrapChunks(text string, firstBudget, continuationBudget int, wrapCondition *tabwrap.Condition) []string {

--- a/internal/treerender/treerender.go
+++ b/internal/treerender/treerender.go
@@ -119,12 +119,12 @@ func RenderTreeWithOptions[T any](
 	wrapCondition *tabwrap.Condition,
 	continuationIndent ContinuationIndent,
 ) []Row {
-	if root == nil {
-		return nil
-	}
 	validateContinuationIndent(continuationIndent)
 	if wrapCondition == nil {
 		wrapCondition = defaultWrapCondition
+	}
+	if root == nil {
+		return nil
 	}
 
 	sw := newStyleWidths(style)

--- a/internal/treerender/treerender.go
+++ b/internal/treerender/treerender.go
@@ -2,9 +2,12 @@ package treerender
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/apstndb/go-tabwrap"
 )
+
+var defaultWrapCondition = tabwrap.NewCondition()
 
 type Node struct {
 	Text     string
@@ -116,7 +119,7 @@ func RenderTreeWithOptions[T any](
 		return nil
 	}
 	if wrapCondition == nil {
-		wrapCondition = tabwrap.NewCondition()
+		wrapCondition = defaultWrapCondition
 	}
 
 	sw := newStyleWidths(style)
@@ -235,14 +238,18 @@ func wrapChunks(text string, firstBudget, continuationBudget int, wrapCondition 
 		for rawLine != "" {
 			rawChunk := wrapCondition.Truncate(rawLine, budget, "")
 			if rawChunk == "" {
-				rawChunk = rawLine[:1]
+				_, size := utf8.DecodeRuneInString(rawLine)
+				if size <= 0 {
+					size = 1
+				}
+				rawChunk = rawLine[:size]
 			}
 			chunk := rawChunk
 			if wrapCondition.TrimTrailingSpace {
 				chunk = strings.TrimRight(chunk, " \t")
 			}
 			lines = append(lines, chunk)
-			rawLine = strings.TrimPrefix(rawLine, rawChunk)
+			rawLine = rawLine[len(rawChunk):]
 			budget = continuationBudget
 		}
 	}

--- a/internal/treerender/treerender_test.go
+++ b/internal/treerender/treerender_test.go
@@ -3,6 +3,7 @@ package treerender
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/apstndb/go-tabwrap"
 	"github.com/google/go-cmp/cmp"
@@ -171,5 +172,35 @@ func TestRenderTreeWithOptions_HangingIndentAnchor(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("RenderTreeWithOptions() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRenderTreeWithOptions_TinyBudgetKeepsUTF8Valid(t *testing.T) {
+	root := &Node{
+		Text: "root",
+		Children: []*Node{
+			{Text: "あい"},
+		},
+	}
+
+	got := RenderTreeWithOptions(
+		root,
+		DefaultStyle(),
+		func(n *Node) string { return n.Text },
+		func(n *Node) []*Node { return n.Children },
+		nil,
+		4, // child budget becomes 1 after "+- "
+		nil,
+		ContinuationIndentTree,
+	)
+
+	if len(got) != 2 {
+		t.Fatalf("RenderTreeWithOptions() rows = %d, want 2", len(got))
+	}
+	if !utf8.ValidString(got[1].NodeText) {
+		t.Fatalf("wrapped NodeText = %q, want valid UTF-8", got[1].NodeText)
+	}
+	if diff := cmp.Diff("あ\nい", got[1].NodeText); diff != "" {
+		t.Fatalf("wrapped NodeText mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/treerender/treerender_test.go
+++ b/internal/treerender/treerender_test.go
@@ -1,8 +1,10 @@
 package treerender
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/apstndb/go-tabwrap"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -134,5 +136,40 @@ func TestRender_CustomStyle(t *testing.T) {
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("Render() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRenderTreeWithOptions_HangingIndentAnchor(t *testing.T) {
+	root := &Node{
+		Text: "root",
+		Children: []*Node{
+			{Text: "[Input] Batch Scan <Row>"},
+			{Text: "tail"},
+		},
+	}
+
+	got := RenderTreeWithOptions(
+		root,
+		DefaultStyle(),
+		func(n *Node) string { return n.Text },
+		func(n *Node) []*Node { return n.Children },
+		func(n *Node) string {
+			if strings.HasPrefix(n.Text, "[Input] ") {
+				return "[Input] "
+			}
+			return ""
+		},
+		21,
+		tabwrap.NewCondition(),
+		ContinuationIndentAnchor,
+	)
+
+	want := []Row{
+		{TreePart: "", NodeText: "root"},
+		{TreePart: "+- \n|          ", NodeText: "[Input] Batch Scan\n <Row>"},
+		{TreePart: "+- ", NodeText: "tail"},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("RenderTreeWithOptions() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/treerender/treerender_test.go
+++ b/internal/treerender/treerender_test.go
@@ -204,3 +204,74 @@ func TestRenderTreeWithOptions_TinyBudgetKeepsUTF8Valid(t *testing.T) {
 		t.Fatalf("wrapped NodeText mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestRenderTreeWithOptions_SkipsAnchorCallbackWhenUnused(t *testing.T) {
+	root := &Node{
+		Text: "root",
+		Children: []*Node{
+			{Text: "[Input] child"},
+		},
+	}
+
+	calls := 0
+	getAnchor := func(n *Node) string {
+		calls++
+		return "[Input] "
+	}
+
+	_ = RenderTreeWithOptions(
+		root,
+		DefaultStyle(),
+		func(n *Node) string { return n.Text },
+		func(n *Node) []*Node { return n.Children },
+		getAnchor,
+		0,
+		nil,
+		ContinuationIndentAnchor,
+	)
+	if calls != 0 {
+		t.Fatalf("anchor callback calls = %d, want 0 when wrapping is disabled", calls)
+	}
+
+	_ = RenderTreeWithOptions(
+		root,
+		DefaultStyle(),
+		func(n *Node) string { return n.Text },
+		func(n *Node) []*Node { return n.Children },
+		getAnchor,
+		20,
+		nil,
+		ContinuationIndentTree,
+	)
+	if calls != 0 {
+		t.Fatalf("anchor callback calls = %d, want 0 when continuation indent is tree-aligned", calls)
+	}
+}
+
+func TestRenderTreeWithOptions_InvalidContinuationIndentPanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("RenderTreeWithOptions() did not panic for invalid continuation indent")
+		}
+	}()
+
+	root := &Node{
+		Text: "root",
+		Children: []*Node{
+			{Text: "child"},
+		},
+	}
+
+	_ = RenderTreeWithOptions(
+		root,
+		DefaultStyle(),
+		func(n *Node) string { return n.Text },
+		func(n *Node) []*Node { return n.Children },
+		nil,
+		20,
+		nil,
+		ContinuationIndent(99),
+	)
+}

--- a/internal/treerender/treerender_test.go
+++ b/internal/treerender/treerender_test.go
@@ -149,21 +149,26 @@ func TestRenderTreeWithOptions_HangingIndentAnchor(t *testing.T) {
 		},
 	}
 
-	got := RenderTreeWithOptions(
+	got, err := RenderTreeWithOptions(
 		root,
 		DefaultStyle(),
 		func(n *Node) string { return n.Text },
 		func(n *Node) []*Node { return n.Children },
-		func(n *Node) string {
-			if strings.HasPrefix(n.Text, "[Input] ") {
-				return "[Input] "
-			}
-			return ""
+		RenderOptions[Node]{
+			GetContinuationAnchor: func(n *Node) string {
+				if strings.HasPrefix(n.Text, "[Input] ") {
+					return "[Input] "
+				}
+				return ""
+			},
+			WrapWidth:          21,
+			WrapCondition:      tabwrap.NewCondition(),
+			ContinuationIndent: ContinuationIndentAnchor,
 		},
-		21,
-		tabwrap.NewCondition(),
-		ContinuationIndentAnchor,
 	)
+	if err != nil {
+		t.Fatalf("RenderTreeWithOptions() error = %v", err)
+	}
 
 	want := []Row{
 		{TreePart: "", NodeText: "root"},
@@ -183,16 +188,18 @@ func TestRenderTreeWithOptions_TinyBudgetKeepsUTF8Valid(t *testing.T) {
 		},
 	}
 
-	got := RenderTreeWithOptions(
+	got, err := RenderTreeWithOptions(
 		root,
 		DefaultStyle(),
 		func(n *Node) string { return n.Text },
 		func(n *Node) []*Node { return n.Children },
-		nil,
-		4, // child budget becomes 1 after "+- "
-		nil,
-		ContinuationIndentTree,
+		RenderOptions[Node]{
+			WrapWidth: 4, // child budget becomes 1 after "+- "
+		},
 	)
+	if err != nil {
+		t.Fatalf("RenderTreeWithOptions() error = %v", err)
+	}
 
 	if len(got) != 2 {
 		t.Fatalf("RenderTreeWithOptions() rows = %d, want 2", len(got))
@@ -219,43 +226,44 @@ func TestRenderTreeWithOptions_SkipsAnchorCallbackWhenUnused(t *testing.T) {
 		return "[Input] "
 	}
 
-	_ = RenderTreeWithOptions(
+	_, err := RenderTreeWithOptions(
 		root,
 		DefaultStyle(),
 		func(n *Node) string { return n.Text },
 		func(n *Node) []*Node { return n.Children },
-		getAnchor,
-		0,
-		nil,
-		ContinuationIndentAnchor,
+		RenderOptions[Node]{
+			GetContinuationAnchor: getAnchor,
+			ContinuationIndent:    ContinuationIndentAnchor,
+		},
 	)
+	if err != nil {
+		t.Fatalf("RenderTreeWithOptions() error = %v", err)
+	}
 	if calls != 0 {
 		t.Fatalf("anchor callback calls = %d, want 0 when wrapping is disabled", calls)
 	}
 
-	_ = RenderTreeWithOptions(
+	_, err = RenderTreeWithOptions(
 		root,
 		DefaultStyle(),
 		func(n *Node) string { return n.Text },
 		func(n *Node) []*Node { return n.Children },
-		getAnchor,
-		20,
-		nil,
-		ContinuationIndentTree,
+		RenderOptions[Node]{
+			GetContinuationAnchor: getAnchor,
+			WrapWidth:             20,
+			ContinuationIndent:    ContinuationIndentTree,
+		},
 	)
+	if err != nil {
+		t.Fatalf("RenderTreeWithOptions() error = %v", err)
+	}
 	if calls != 0 {
 		t.Fatalf("anchor callback calls = %d, want 0 when continuation indent is tree-aligned", calls)
 	}
 }
 
-func TestRenderTreeWithOptions_InvalidContinuationIndentPanics(t *testing.T) {
+func TestRenderTreeWithOptions_InvalidContinuationIndentErrors(t *testing.T) {
 	t.Parallel()
-
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("RenderTreeWithOptions() did not panic for invalid continuation indent")
-		}
-	}()
 
 	root := &Node{
 		Text: "root",
@@ -264,14 +272,37 @@ func TestRenderTreeWithOptions_InvalidContinuationIndentPanics(t *testing.T) {
 		},
 	}
 
-	_ = RenderTreeWithOptions(
+	_, err := RenderTreeWithOptions(
 		root,
 		DefaultStyle(),
 		func(n *Node) string { return n.Text },
 		func(n *Node) []*Node { return n.Children },
-		nil,
-		0,
-		nil,
-		ContinuationIndent(99),
+		RenderOptions[Node]{
+			ContinuationIndent: ContinuationIndent(99),
+		},
 	)
+	if err == nil {
+		t.Fatal("RenderTreeWithOptions() error = nil, want non-nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "invalid ContinuationIndent") {
+		t.Fatalf("RenderTreeWithOptions() error = %q, want invalid ContinuationIndent", got)
+	}
+}
+
+func TestRenderTreeWithOptions_NilRootStillValidatesOptions(t *testing.T) {
+	t.Parallel()
+
+	var root *Node
+	_, err := RenderTreeWithOptions(
+		root,
+		DefaultStyle(),
+		func(n *Node) string { return n.Text },
+		func(n *Node) []*Node { return n.Children },
+		RenderOptions[Node]{
+			ContinuationIndent: ContinuationIndent(99),
+		},
+	)
+	if err == nil {
+		t.Fatal("RenderTreeWithOptions(nil) error = nil, want non-nil")
+	}
 }

--- a/internal/treerender/treerender_test.go
+++ b/internal/treerender/treerender_test.go
@@ -270,7 +270,7 @@ func TestRenderTreeWithOptions_InvalidContinuationIndentPanics(t *testing.T) {
 		func(n *Node) string { return n.Text },
 		func(n *Node) []*Node { return n.Children },
 		nil,
-		20,
+		0,
 		nil,
 		ContinuationIndent(99),
 	)

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -37,16 +37,13 @@ type RowWithPredicates struct {
 }
 
 type renderedNode struct {
-	ID             int32
-	NodeText       string
-	Predicates     []string
-	ExecutionStats stats.ExecutionStats
-	ChildLinks     map[string][]*spannerplan.ResolvedChildLink
-	Children       []*renderedNode
-}
-
-func (n *renderedNode) lineCount() int {
-	return strings.Count(n.NodeText, "\n") + 1
+	ID                 int32
+	ContinuationAnchor string
+	NodeText           string
+	Predicates         []string
+	ExecutionStats     stats.ExecutionStats
+	ChildLinks         map[string][]*spannerplan.ResolvedChildLink
+	Children           []*renderedNode
 }
 
 func (r RowWithPredicates) Text() string {
@@ -82,13 +79,23 @@ type options struct {
 	disallowUnknownStats bool
 	queryplanOptions     []spannerplan.Option
 	style                treerender.Style
-	prefixMetrics        treerender.PrefixMetrics
 	compact              bool
+	continuationIndent   ContinuationIndent
 	wrapWidth            *int
 	wrapper              *tabwrap.Condition
 }
 
 type Option func(*options)
+
+// ContinuationIndent controls how wrapped continuation lines are aligned.
+type ContinuationIndent int
+
+const (
+	// ContinuationIndentTree preserves the current behavior: continuation lines align only to the tree prefix.
+	ContinuationIndentTree ContinuationIndent = iota
+	// ContinuationIndentNodePrefix hangs continuation lines after a node-local prefix such as `[Input] `.
+	ContinuationIndentNodePrefix
+)
 
 func DisallowUnknownStats() Option {
 	return func(o *options) {
@@ -121,6 +128,16 @@ func EnableCompact() Option {
 	}
 }
 
+// WithContinuationIndent selects how wrapped continuation lines are aligned.
+// The default [ContinuationIndentTree] preserves the current behavior.
+// [ContinuationIndentNodePrefix] is opt-in and hangs continuation lines after a
+// node-local prefix such as `[Input] ` or `[Map] ` when present.
+func WithContinuationIndent(indent ContinuationIndent) Option {
+	return func(o *options) {
+		o.continuationIndent = indent
+	}
+}
+
 func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredicates, err error) {
 	o := options{
 		style:   treerender.DefaultStyle(),
@@ -138,9 +155,8 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 	if o.wrapWidth != nil && *o.wrapWidth < 0 {
 		return nil, fmt.Errorf("wrap width cannot be negative: %d", *o.wrapWidth)
 	}
-	o.prefixMetrics = treerender.NewPrefixMetrics(o.style)
 
-	root, err := buildRenderedTree(qp, nil, 0, &o)
+	root, err := buildRenderedTree(qp, nil, &o)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build rendered tree: %w", err)
 	}
@@ -148,9 +164,17 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 		return nil, nil
 	}
 
-	renderRows := treerender.RenderTree(root, o.style,
+	wrapWidth := 0
+	if o.wrapWidth != nil {
+		wrapWidth = *o.wrapWidth
+	}
+	renderRows := treerender.RenderTreeWithOptions(root, o.style,
 		func(n *renderedNode) string { return n.NodeText },
 		func(n *renderedNode) []*renderedNode { return n.Children },
+		func(n *renderedNode) string { return n.ContinuationAnchor },
+		wrapWidth,
+		o.wrapper,
+		mapContinuationIndent(o.continuationIndent),
 	)
 	nodes := collectPreorder(root)
 	if len(renderRows) != len(nodes) {
@@ -161,9 +185,8 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 	for i, node := range nodes {
 		row := renderRows[i]
 		gotLines := strings.Count(row.NodeText, "\n") + 1
-		wantLines := node.lineCount()
-		if gotLines != wantLines {
-			return nil, fmt.Errorf("unexpected rendered node line count for node %d: got %d lines, want %d", node.ID, gotLines, wantLines)
+		if wantTreeLines := strings.Count(row.TreePart, "\n") + 1; gotLines != wantTreeLines {
+			return nil, fmt.Errorf("unexpected rendered row line count for node %d: tree=%d node=%d", node.ID, wantTreeLines, gotLines)
 		}
 		result = append(result, RowWithPredicates{
 			ID:             node.ID,
@@ -178,7 +201,7 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 	return result, nil
 }
 
-func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink, level int, opts *options) (*renderedNode, error) {
+func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink, opts *options) (*renderedNode, error) {
 	if !qp.IsVisible(link) {
 		return nil, nil
 	}
@@ -187,17 +210,8 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 
 	node := qp.GetNodeByChildLink(link)
 	linkType := qp.GetLinkType(link)
-	nodeText := lox.IfOrEmpty(linkType != "", "["+linkType+"]"+sep) + spannerplan.NodeTitle(node, opts.queryplanOptions...)
-	// Only wrap when width is set and positive; 0 matches CLI/reference "no wrapping".
-	if opts.wrapWidth != nil && *opts.wrapWidth > 0 {
-		// Prefix width matches RenderTree (includes EdgeSeparator). Do not subtract sep again:
-		// it is either absent from nodeText (empty linkType) or already inside the wrapped string.
-		budget := *opts.wrapWidth - opts.prefixMetrics.MaxWidthForDepth(level)
-		if budget < 1 {
-			budget = 1
-		}
-		nodeText = opts.wrapper.Wrap(nodeText, budget)
-	}
+	continuationAnchor := lox.IfOrEmpty(linkType != "", "["+linkType+"]"+sep)
+	nodeText := continuationAnchor + spannerplan.NodeTitle(node, opts.queryplanOptions...)
 
 	var predicates []string
 	for _, cl := range node.GetChildLinks() {
@@ -227,15 +241,16 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 
 	visibleChildLinks := qp.VisibleChildLinks(node)
 	rendered := &renderedNode{
-		ID:             node.GetIndex(),
-		NodeText:       nodeText,
-		Predicates:     predicates,
-		ExecutionStats: *executionStats,
-		ChildLinks:     childLinks,
+		ID:                 node.GetIndex(),
+		ContinuationAnchor: continuationAnchor,
+		NodeText:           nodeText,
+		Predicates:         predicates,
+		ExecutionStats:     *executionStats,
+		ChildLinks:         childLinks,
 	}
 
 	for _, child := range visibleChildLinks {
-		renderedChild, err := buildRenderedTree(qp, child, level+1, opts)
+		renderedChild, err := buildRenderedTree(qp, child, opts)
 		if err != nil {
 			return nil, fmt.Errorf("buildRenderedTree failed on child link %v: %w", child, err)
 		}
@@ -244,6 +259,15 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 		}
 	}
 	return rendered, nil
+}
+
+func mapContinuationIndent(indent ContinuationIndent) treerender.ContinuationIndent {
+	switch indent {
+	case ContinuationIndentNodePrefix:
+		return treerender.ContinuationIndentAnchor
+	default:
+		return treerender.ContinuationIndentTree
+	}
 }
 
 func collectPreorder(root *renderedNode) []*renderedNode {

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -25,7 +25,8 @@ func newDefaultWrapCondition() *tabwrap.Condition {
 
 type RowWithPredicates struct {
 	ID int32
-	// TreePart stores the ASCII tree prefix as newline-joined lines (one per line of NodeText).
+	// TreePart stores everything rendered before NodeText on each visual line: the ASCII tree prefix
+	// plus any continuation padding inserted by the renderer for wrapping / hanging indent.
 	// Prefer [RowWithPredicates.TreePartString] or [RowWithPredicates.TreePartLines] instead of
 	// reading this field directly, so callers stay decoupled if the storage shape changes.
 	TreePart       string

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -156,6 +156,9 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 	if o.wrapWidth != nil && *o.wrapWidth < 0 {
 		return nil, fmt.Errorf("wrap width cannot be negative: %d", *o.wrapWidth)
 	}
+	if err := validateContinuationIndent(o.continuationIndent); err != nil {
+		return nil, err
+	}
 
 	root, err := buildRenderedTree(qp, nil, &o)
 	if err != nil {
@@ -266,8 +269,19 @@ func mapContinuationIndent(indent ContinuationIndent) treerender.ContinuationInd
 	switch indent {
 	case ContinuationIndentNodePrefix:
 		return treerender.ContinuationIndentAnchor
-	default:
+	case ContinuationIndentTree:
 		return treerender.ContinuationIndentTree
+	default:
+		panic(fmt.Sprintf("unknown ContinuationIndent: %d", indent))
+	}
+}
+
+func validateContinuationIndent(indent ContinuationIndent) error {
+	switch indent {
+	case ContinuationIndentTree, ContinuationIndentNodePrefix:
+		return nil
+	default:
+		return fmt.Errorf("unknown ContinuationIndent: %d", indent)
 	}
 }
 

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -172,14 +172,19 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 	if o.wrapWidth != nil {
 		wrapWidth = *o.wrapWidth
 	}
-	renderRows := treerender.RenderTreeWithOptions(root, o.style,
+	renderRows, err := treerender.RenderTreeWithOptions(root, o.style,
 		func(n *renderedNode) string { return n.NodeText },
 		func(n *renderedNode) []*renderedNode { return n.Children },
-		func(n *renderedNode) string { return n.ContinuationAnchor },
-		wrapWidth,
-		o.wrapper,
-		mapContinuationIndent(o.continuationIndent),
+		treerender.RenderOptions[renderedNode]{
+			GetContinuationAnchor: func(n *renderedNode) string { return n.ContinuationAnchor },
+			WrapWidth:             wrapWidth,
+			WrapCondition:         o.wrapper,
+			ContinuationIndent:    mapContinuationIndent(o.continuationIndent),
+		},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to render tree rows: %w", err)
+	}
 	nodes := collectPreorder(root)
 	if len(renderRows) != len(nodes) {
 		return nil, fmt.Errorf("unexpected rendered row count: got=%d want=%d", len(renderRows), len(nodes))

--- a/plantree/plantree_test.go
+++ b/plantree/plantree_test.go
@@ -2,6 +2,7 @@ package plantree
 
 import (
 	_ "embed"
+	"strings"
 	"testing"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
@@ -188,6 +189,12 @@ func TestProcessPlan_NegativeWrapWidthErrors(t *testing.T) {
 	}
 }
 
+func invalidContinuationIndentOption() Option {
+	return func(o *options) {
+		o.continuationIndent = ContinuationIndent(99)
+	}
+}
+
 func TestProcessPlan_CompactFormatting(t *testing.T) {
 	opts := append(currentOptions(), EnableCompact())
 	rows, err := ProcessPlan(decodeDCAPlan(t), opts...)
@@ -304,5 +311,17 @@ func TestProcessPlan_ContinuationIndentNodePrefix(t *testing.T) {
 		NodeText: got.NodeText,
 	}); diff != "" {
 		t.Fatalf("row 1 mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestProcessPlan_InvalidContinuationIndentErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := ProcessPlan(hangingIndentPlan(t), append(currentOptions(), invalidContinuationIndentOption())...)
+	if err == nil {
+		t.Fatal("ProcessPlan(invalid continuation indent) error = nil, want non-nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "unknown ContinuationIndent") {
+		t.Fatalf("ProcessPlan() error = %q, want unknown ContinuationIndent", got)
 	}
 }

--- a/plantree/plantree_test.go
+++ b/plantree/plantree_test.go
@@ -6,6 +6,7 @@ import (
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/apstndb/spannerplan"
 )
@@ -248,5 +249,60 @@ func TestProcessPlan_InvisibleRootReturnsEmpty(t *testing.T) {
 	}
 	if len(rows) != 0 {
 		t.Fatalf("ProcessPlan() rows = %v, want empty", rows)
+	}
+}
+
+func hangingIndentPlan(t *testing.T) *spannerplan.QueryPlan {
+	t.Helper()
+
+	qp, err := spannerplan.New([]*sppb.PlanNode{
+		{
+			Index:       0,
+			DisplayName: "Cross Apply",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 1},
+				{ChildIndex: 2, Type: "Map"},
+			},
+		},
+		{
+			Index:       1,
+			DisplayName: "Batch Scan",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			Metadata: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"execution_method": structpb.NewStringValue("Row"),
+			}},
+		},
+		{
+			Index:       2,
+			DisplayName: "Serialize Result",
+			Kind:        sppb.PlanNode_RELATIONAL,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return qp
+}
+
+func TestProcessPlan_ContinuationIndentNodePrefix(t *testing.T) {
+	opts := append(currentOptions(), WithWrapWidth(21), WithContinuationIndent(ContinuationIndentNodePrefix))
+	rows, err := ProcessPlan(hangingIndentPlan(t), opts...)
+	if err != nil {
+		t.Fatalf("ProcessPlan() error = %v", err)
+	}
+
+	got := rowByID(t, rows, 1)
+	want := RowWithPredicates{
+		ID:       1,
+		TreePart: "+- \n|          ",
+		NodeText: "[Input] Batch Scan\n <Row>",
+	}
+	if diff := cmp.Diff(want, RowWithPredicates{
+		ID:       got.ID,
+		TreePart: got.TreePartString(),
+		NodeText: got.NodeText,
+	}); diff != "" {
+		t.Fatalf("row 1 mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Summary
- move plantree wrap decisions into `internal/treerender`
- add opt-in hanging-indent support via `plantree.WithContinuationIndent(plantree.ContinuationIndentNodePrefix)`
- preserve the current wrapping behavior by default and cover both modes with tests

Closes #20