### PR TITLE
feat: expose hanging indent in reference

### DIFF
--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -208,7 +208,7 @@ Predicates(identified by ID):
 ```
 
 ```
- $ rendertree --wrap-width=50 --hanging-indent < testdata/distributed_cross_apply.yaml
+$ rendertree --wrap-width=50 --hanging-indent < testdata/distributed_cross_apply.yaml
 ...
 |  13 |          +- [Input] Batch Scan on $v2 <Row> (scan_ |
 |     |          |          method: Row)                   |

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -178,6 +178,9 @@ rendertree supports a compact format and wrapping for limited width environment.
   - Whitespaces are not inserted for operator and metadata display unless it causes ambiguity.
 - `--wrap-width` specifies the number of characters at which to wrap the content of the Operator column.
   - The tree won't be broken even when lines are wrapped.
+- `--hanging-indent` enables hanging indent for wrapped lines.
+  - Wrapped continuation lines align after node-local prefixes such as `[Input] ` and `[Map] `.
+  - Without this flag, wrapped lines keep the original tree-aligned indentation.
 
 ```
 $ rendertree --compact --wrap-width=60 < testdata/distributed_cross_apply.yaml 
@@ -202,4 +205,12 @@ $ rendertree --compact --wrap-width=60 < testdata/distributed_cross_apply.yaml
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
+```
+
+```
+ $ rendertree --wrap-width=50 --hanging-indent < testdata/distributed_cross_apply.yaml
+...
+|  13 |          +- [Input] Batch Scan on $v2 <Row> (scan_ |
+|     |          |          method: Row)                   |
+...
 ```

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -301,6 +301,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	compact := flagSet.Bool("compact", false, "Enable compact format")
 	inlineStats := flagSet.Bool("inline-stats", false, "Enable inline stats")
 	wrapWidth := flagSet.Int("wrap-width", 0, "Number of characters at which to wrap the Operator column content. 0 means no wrapping.")
+	hangingIndent := flagSet.Bool("hanging-indent", false, "Enable hanging indent for wrapped lines after node-local prefixes such as [Input] and [Map]")
 
 	var custom stringList
 	flagSet.Var(&custom, "custom", "Add a custom table column definition in NAME:TEMPLATE[:ALIGNMENT[:INLINE_TYPE]] form (mutually exclusive with --custom-file)")
@@ -391,6 +392,9 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 
 	if *wrapWidth > 0 {
 		opts = append(opts, plantree.WithWrapWidth(*wrapWidth))
+	}
+	if *hangingIndent {
+		opts = append(opts, plantree.WithContinuationIndent(plantree.ContinuationIndentNodePrefix))
 	}
 
 	b, err := io.ReadAll(stdin)

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -513,6 +513,11 @@ func TestRun_UsageErrors(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:        "invalid hanging-indent",
+			args:        []string{"-hanging-indent=broken"},
+			wantErrText: "invalid boolean value \"broken\" for -hanging-indent",
+		},
 	}
 
 	for _, tt := range tests {
@@ -572,4 +577,44 @@ func TestRun_HelpReturnsNil(t *testing.T) {
 	if !strings.Contains(stderr.String(), "-mode") {
 		t.Fatalf("stderr = %q, want usage output", stderr.String())
 	}
+}
+
+func TestRun_HangingIndent(t *testing.T) {
+	t.Parallel()
+
+	var defaultStdout bytes.Buffer
+	var defaultStderr bytes.Buffer
+	if err := run([]string{"-mode", "plan", "-wrap-width", "50"}, bytes.NewReader(dcaYAML), &defaultStdout, &defaultStderr); err != nil {
+		t.Fatalf("run(default) error = %v", err)
+	}
+
+	var hangingStdout bytes.Buffer
+	var hangingStderr bytes.Buffer
+	if err := run([]string{"-mode", "plan", "-wrap-width", "50", "-hanging-indent"}, bytes.NewReader(dcaYAML), &hangingStdout, &hangingStderr); err != nil {
+		t.Fatalf("run(-hanging-indent) error = %v", err)
+	}
+
+	defaultLine := lineContaining(defaultStdout.String(), "method: Row)")
+	hangingLine := lineContaining(hangingStdout.String(), "method: Row)")
+	if defaultLine == "" || hangingLine == "" {
+		t.Fatalf("expected wrapped Batch Scan continuation line\ndefault=%q\nhanging=%q", defaultLine, hangingLine)
+	}
+	if defaultLine == hangingLine {
+		t.Fatalf("continuation line unchanged:\n%s", defaultLine)
+	}
+	if !strings.Contains(defaultLine, "|  method: Row)") {
+		t.Fatalf("default line = %q, want tree-aligned continuation marker", defaultLine)
+	}
+	if strings.Contains(hangingLine, "|  method: Row)") {
+		t.Fatalf("hanging line = %q, want node-prefix hanging indent", hangingLine)
+	}
+}
+
+func lineContaining(s, needle string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
 }

--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -29,6 +29,30 @@ const (
 	RenderModeProfile RenderMode = "PROFILE"
 )
 
+type options struct {
+	wrapWidth     int
+	hangingIndent bool
+}
+
+// Option configures optional rendering behavior for [RenderTreeTableWithOptions].
+type Option func(*options)
+
+// WithWrapWidth sets the maximum total rendered line width, including the tree prefix.
+// A value of 0 disables wrapping. Negative values make [RenderTreeTableWithOptions] return an error.
+func WithWrapWidth(width int) Option {
+	return func(o *options) {
+		o.wrapWidth = width
+	}
+}
+
+// WithHangingIndent hangs wrapped continuation lines after node-local prefixes such as
+// `[Input] ` and `[Map] ` instead of keeping the default tree-aligned indentation.
+func WithHangingIndent() Option {
+	return func(o *options) {
+		o.hangingIndent = true
+	}
+}
+
 // ParseRenderMode parses a string into a RenderMode.
 // Valid values are "AUTO", "PLAN", and "PROFILE" (case-insensitive).
 func ParseRenderMode(s string) (RenderMode, error) {
@@ -48,12 +72,25 @@ func ParseRenderMode(s string) (RenderMode, error) {
 // It supports different render modes (AUTO, PLAN, PROFILE) and formats (TRADITIONAL, CURRENT, COMPACT).
 // The wrapWidth parameter controls text wrapping (0 disables wrapping).
 func RenderTreeTable(planNodes []*sppb.PlanNode, mode RenderMode, format Format, wrapWidth int) (string, error) {
+	return RenderTreeTableWithOptions(planNodes, mode, format, WithWrapWidth(wrapWidth))
+}
+
+// RenderTreeTableWithOptions renders Spanner plan nodes as an ASCII table with optional rendering configuration.
+func RenderTreeTableWithOptions(planNodes []*sppb.PlanNode, mode RenderMode, format Format, opts ...Option) (string, error) {
+	o := options{}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		opt(&o)
+	}
+
 	// Validate input parameters
 	if len(planNodes) == 0 {
 		return "", fmt.Errorf("planNodes cannot be empty")
 	}
-	if wrapWidth < 0 {
-		return "", fmt.Errorf("wrapWidth cannot be negative: %d", wrapWidth)
+	if o.wrapWidth < 0 {
+		return "", fmt.Errorf("wrapWidth cannot be negative: %d", o.wrapWidth)
 	}
 
 	var withStats bool
@@ -68,7 +105,7 @@ func RenderTreeTable(planNodes []*sppb.PlanNode, mode RenderMode, format Format,
 		return "", fmt.Errorf("unknown render mode: %s", mode)
 	}
 
-	rendered, err := processTree(planNodes, format, wrapWidth)
+	rendered, err := processTree(planNodes, format, o)
 	if err != nil {
 		return "", err
 	}
@@ -202,18 +239,21 @@ func ParseFormat(str string) (Format, error) {
 }
 
 // processTree converts Spanner plan nodes into a structured tree representation.
-func processTree(planNodes []*sppb.PlanNode, format Format, wrapWidth int) ([]plantree.RowWithPredicates, error) {
+func processTree(planNodes []*sppb.PlanNode, format Format, opts options) ([]plantree.RowWithPredicates, error) {
 	qp, err := queryplan.New(planNodes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create query plan: %w", err)
 	}
 
-	opts := optsForFormat(format)
-	if wrapWidth > 0 {
-		opts = append(opts, plantree.WithWrapWidth(wrapWidth))
+	plantreeOpts := optsForFormat(format)
+	if opts.wrapWidth > 0 {
+		plantreeOpts = append(plantreeOpts, plantree.WithWrapWidth(opts.wrapWidth))
+	}
+	if opts.hangingIndent {
+		plantreeOpts = append(plantreeOpts, plantree.WithContinuationIndent(plantree.ContinuationIndentNodePrefix))
 	}
 
-	return plantree.ProcessPlan(qp, opts...)
+	return plantree.ProcessPlan(qp, plantreeOpts...)
 }
 
 // optsForFormat returns the appropriate rendering options for the given format.

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -21,6 +21,15 @@ func loadRealPlan(t *testing.T) string {
 	return string(b)
 }
 
+func loadWrappedPlan(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("../../cmd/rendertree/impl/testdata/distributed_cross_apply.yaml")
+	if err != nil {
+		t.Fatalf("failed to read wrapped plan fixture: %v", err)
+	}
+	return string(b)
+}
+
 func Test_RenderTreeTable_withRealPlan_ALL_MODES_AND_FORMATS(t *testing.T) {
 	input := loadRealPlan(t)
 	tests := []struct {
@@ -376,4 +385,77 @@ func TestRenderTreeTable_InputValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRenderTreeTableWithOptions_ContinuationIndentNodePrefix(t *testing.T) {
+	input := loadWrappedPlan(t)
+	stats, _, err := queryplan.ExtractQueryPlan([]byte(input))
+	if err != nil {
+		t.Fatalf("Failed to extract query plan: %v", err)
+	}
+
+	planNodes := stats.GetQueryPlan().GetPlanNodes()
+	base, err := RenderTreeTable(planNodes, RenderModePlan, FormatCurrent, 50)
+	if err != nil {
+		t.Fatalf("RenderTreeTable() error = %v", err)
+	}
+
+	hanging, err := RenderTreeTableWithOptions(
+		planNodes,
+		RenderModePlan,
+		FormatCurrent,
+		WithWrapWidth(50),
+		WithHangingIndent(),
+	)
+	if err != nil {
+		t.Fatalf("RenderTreeTableWithOptions() error = %v", err)
+	}
+
+	if base == hanging {
+		t.Fatal("RenderTreeTableWithOptions() output = default output, want hanging indent difference")
+	}
+
+	defaultLine := lineContaining(base, "method: Row)")
+	hangingLine := lineContaining(hanging, "method: Row)")
+	if defaultLine == "" || hangingLine == "" {
+		t.Fatalf("expected wrapped Batch Scan line in both outputs\ndefault=%q\nhanging=%q", defaultLine, hangingLine)
+	}
+	if !strings.Contains(defaultLine, "|  method: Row)") {
+		t.Fatalf("default line = %q, want tree-aligned continuation marker", defaultLine)
+	}
+	if strings.Contains(hangingLine, "|  method: Row)") {
+		t.Fatalf("hanging line = %q, want node-prefix hanging indent", hangingLine)
+	}
+}
+
+func TestRenderTreeTableWithOptions_NilOption(t *testing.T) {
+	input := loadWrappedPlan(t)
+	stats, _, err := queryplan.ExtractQueryPlan([]byte(input))
+	if err != nil {
+		t.Fatalf("Failed to extract query plan: %v", err)
+	}
+
+	planNodes := stats.GetQueryPlan().GetPlanNodes()
+	got, err := RenderTreeTableWithOptions(planNodes, RenderModePlan, FormatCurrent, nil, WithWrapWidth(50))
+	if err != nil {
+		t.Fatalf("RenderTreeTableWithOptions() error = %v", err)
+	}
+
+	want, err := RenderTreeTable(planNodes, RenderModePlan, FormatCurrent, 50)
+	if err != nil {
+		t.Fatalf("RenderTreeTable() error = %v", err)
+	}
+
+	if got != want {
+		t.Fatal("RenderTreeTableWithOptions(nil, WithWrapWidth(50)) output != RenderTreeTable(..., 50)")
+	}
+}
+
+func lineContaining(s, needle string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
 }

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -23,7 +23,7 @@ func loadRealPlan(t *testing.T) string {
 
 func loadWrappedPlan(t *testing.T) string {
 	t.Helper()
-	b, err := os.ReadFile("../../cmd/rendertree/impl/testdata/distributed_cross_apply.yaml")
+	b, err := os.ReadFile("testdata/distributed_cross_apply.yaml")
 	if err != nil {
 		t.Fatalf("failed to read wrapped plan fixture: %v", err)
 	}

--- a/plantree/reference/testdata/distributed_cross_apply.yaml
+++ b/plantree/reference/testdata/distributed_cross_apply.yaml
@@ -1,0 +1,232 @@
+metadata:
+    rowType:
+        fields:
+            - name: albumtitle
+              type:
+                code: STRING
+    transaction:
+        readTimestamp: "2025-04-20T03:15:18.412872Z"
+    undeclaredParameters: {}
+stats:
+    queryPlan:
+        planNodes:
+            - childLinks:
+                - childIndex: 1
+                - childIndex: 28
+                  type: Split Range
+              displayName: Distributed Union
+              kind: RELATIONAL
+              metadata:
+                distribution_table: AlbumsByAlbumTitle
+                execution_method: Row
+                split_ranges_aligned: "false"
+                subquery_cluster_node: "1"
+            - childLinks:
+                - childIndex: 2
+                - childIndex: 11
+                  type: Map
+                - childIndex: 25
+                  type: Split Range
+              displayName: Distributed Cross Apply
+              index: 1
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+                subquery_cluster_node: "11"
+            - childLinks:
+                - childIndex: 3
+                - childIndex: 10
+                  variable: v2.Batch
+              displayName: Create Batch
+              index: 2
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+            - childLinks:
+                - childIndex: 4
+              displayName: Distributed Union
+              index: 3
+              kind: RELATIONAL
+              metadata:
+                call_type: Local
+                execution_method: Row
+                subquery_cluster_node: "4"
+            - childLinks:
+                - childIndex: 5
+                - childIndex: 8
+                  variable: v1.AlbumId_1
+                - childIndex: 9
+                  variable: v1.AlbumTitle
+              displayName: Compute Struct
+              index: 4
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+            - childLinks:
+                - childIndex: 6
+                  variable: AlbumId_1
+                - childIndex: 7
+                  variable: AlbumTitle
+              displayName: Scan
+              index: 5
+              kind: RELATIONAL
+              metadata:
+                Full scan: "true"
+                execution_method: Row
+                scan_method: Automatic
+                scan_target: AlbumsByAlbumTitle
+                scan_type: IndexScan
+            - displayName: Reference
+              index: 6
+              kind: SCALAR
+              shortRepresentation:
+                description: AlbumId
+            - displayName: Reference
+              index: 7
+              kind: SCALAR
+              shortRepresentation:
+                description: AlbumTitle
+            - displayName: Reference
+              index: 8
+              kind: SCALAR
+              shortRepresentation:
+                description: $AlbumId_1
+            - displayName: Reference
+              index: 9
+              kind: SCALAR
+              shortRepresentation:
+                description: $AlbumTitle
+            - displayName: Reference
+              index: 10
+              kind: SCALAR
+              shortRepresentation:
+                description: $v1
+            - childLinks:
+                - childIndex: 12
+                - childIndex: 24
+              displayName: Serialize Result
+              index: 11
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+            - childLinks:
+                - childIndex: 13
+                - childIndex: 16
+                  type: Map
+              displayName: Cross Apply
+              index: 12
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+            - childLinks:
+                - childIndex: 14
+                  variable: batched_AlbumId_1
+                - childIndex: 15
+                  variable: batched_AlbumTitle
+              displayName: Scan
+              index: 13
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+                scan_method: Row
+                scan_target: $v2
+                scan_type: BatchScan
+            - displayName: Reference
+              index: 14
+              kind: SCALAR
+              shortRepresentation:
+                description: AlbumId_1
+            - displayName: Reference
+              index: 15
+              kind: SCALAR
+              shortRepresentation:
+                description: AlbumTitle
+            - childLinks:
+                - childIndex: 17
+              displayName: Distributed Union
+              index: 16
+              kind: RELATIONAL
+              metadata:
+                call_type: Local
+                execution_method: Row
+                subquery_cluster_node: "17"
+            - childLinks:
+                - childIndex: 18
+                - childIndex: 23
+                  type: Residual Condition
+              displayName: Filter Scan
+              index: 17
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+                seekable_key_size: "0"
+            - childLinks:
+                - childIndex: 19
+                  variable: AlbumId
+              displayName: Scan
+              index: 18
+              kind: RELATIONAL
+              metadata:
+                Full scan: "true"
+                execution_method: Row
+                scan_method: Row
+                scan_target: SongsBySongGenre
+                scan_type: IndexScan
+            - displayName: Reference
+              index: 19
+              kind: SCALAR
+              shortRepresentation:
+                description: AlbumId
+            - childLinks:
+                - childIndex: 21
+                - childIndex: 22
+              displayName: Function
+              index: 20
+              kind: SCALAR
+              shortRepresentation:
+                description: ($AlbumId = $batched_AlbumId_1)
+            - displayName: Reference
+              index: 21
+              kind: SCALAR
+              shortRepresentation:
+                description: $AlbumId
+            - displayName: Reference
+              index: 22
+              kind: SCALAR
+              shortRepresentation:
+                description: $batched_AlbumId_1
+            - childLinks:
+                - childIndex: 20
+              displayName: Function
+              index: 23
+              kind: SCALAR
+              shortRepresentation:
+                description: ($AlbumId = $batched_AlbumId_1)
+            - displayName: Reference
+              index: 24
+              kind: SCALAR
+              shortRepresentation:
+                description: $batched_AlbumTitle
+            - childLinks:
+                - childIndex: 26
+                - childIndex: 27
+              displayName: Function
+              index: 25
+              kind: SCALAR
+              shortRepresentation:
+                description: ($AlbumId = $AlbumId_1)
+            - displayName: Reference
+              index: 26
+              kind: SCALAR
+              shortRepresentation:
+                description: $AlbumId
+            - displayName: Reference
+              index: 27
+              kind: SCALAR
+              shortRepresentation:
+                description: $AlbumId_1
+            - displayName: Constant
+              index: 28
+              kind: SCALAR
+              shortRepresentation:
+                description: "true"


### PR DESCRIPTION
## Summary
- expose hanging indent via `rendertree --hanging-indent`
- expose hanging indent in `plantree/reference` via functional options
- add tests covering the new CLI flag and reference renderer behavior

## Testing
- go test -v ./...
- golangci-lint run --timeout=5m