### PR TITLE
feat: add structured custom column flag

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,14 @@
+# spannerplan review guide
+
+Prioritize correctness, API behavior, parsing robustness, output stability, and user-facing CLI behavior over micro-optimizations.
+
+For performance feedback:
+
+- Do not suggest allocation micro-optimizations unless the code is on a demonstrated hot path, inside a performance-critical loop, or the change materially improves asymptotic behavior.
+- Avoid comments that only recommend preallocating small slices, hoisting immutable helper values to package scope, or reducing one-time allocations in CLI setup, parsing, and tests unless there is clear evidence that the cost matters.
+- Prefer one consolidated performance comment over multiple near-duplicate comments on the same theme.
+
+For this repository:
+
+- Focus on compatibility of rendered output, public API clarity, and robustness of plan parsing / rendering.
+- Treat command setup and one-shot CLI parsing paths as low priority for allocation tuning.

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -43,7 +43,7 @@ $ gcloud spanner databases execute-sql ${DATABASE_ID} --sql="SELECT * FROM Singe
 
 Note: `--mode=PLAN` and `--mode=PROFILE` can be omitted because the default `--mode=AUTO` can detect whether the input has execution statistics or not.
 
-Rendered stats columns are customizable using `--custom-file`. `--custom-file` and `--custom` are mutually exclusive.
+Rendered stats columns are customizable using `--custom-file` or repeatable `--custom-column` flags. `--custom-file`, `--custom-column`, and deprecated `--custom` are mutually exclusive.
 
 ```
 $ cat custom.yaml
@@ -144,10 +144,15 @@ Predicates(identified by ID):
  34: Seek Condition: (($SingerId' = $batched_SingerId) AND ($AlbumId' = $batched_AlbumId) AND ($TrackId' = $batched_TrackId))
 ```
 
-You can also use `--custom=<name>:<template>[:<align>[:<inline_type>]]`. `--custom` and `--custom-file` cannot be used together.
+You can also use repeatable `--custom-column` flags. Each flag value is a single column definition in JSON or flow-style YAML, using the same schema as `--custom-file`.
 
 ```
-$ cat distributed_cross_apply_profile.yaml | rendertree --custom "ID:{{.FormatID}}:RIGHT,Operator:{{.Text}},CPU Time:{{.ExecutionStats.CpuTime | secsToS}},remote_calls:{{.ExecutionStats.RemoteCalls.Total}}::ALWAYS" 
+$ cat distributed_cross_apply_profile.yaml | \
+    rendertree \
+      --custom-column '{"name":"ID","template":"{{.FormatID}}","alignment":"RIGHT"}' \
+      --custom-column '{"name":"Operator","template":"{{.Text}}"}' \
+      --custom-column '{"name":"CPU Time","template":"{{.ExecutionStats.CpuTime | secsToS}}"}' \
+      --custom-column '{"name":"remote_calls","template":"{{.ExecutionStats.RemoteCalls.Total}}","inline":"ALWAYS"}'
 +-----+-------------------------------------------------------------------------------------------+----------+
 | ID  | Operator                                                                                  | CPU Time |
 +-----+-------------------------------------------------------------------------------------------+----------+
@@ -168,6 +173,8 @@ Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
 ```
+
+The older `--custom=<name>:<template>[:<align>[:<inline_type>]]` form is still accepted for compatibility, but it is deprecated because the delimiter-based mini-language cannot represent all valid template strings robustly.
 
 ## Options for narrower width
 

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -242,6 +242,17 @@ func (s *stringList) Set(s2 string) error {
 	return nil
 }
 
+type repeatableStringList []string
+
+func (s *repeatableStringList) String() string {
+	return fmt.Sprint([]string(*s))
+}
+
+func (s *repeatableStringList) Set(s2 string) error {
+	*s = append(*s, s2)
+	return nil
+}
+
 const jsonSnippetLen = 140
 
 type PrintMode int
@@ -290,7 +301,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	flagSet := flag.NewFlagSet("rendertree", flag.ContinueOnError)
 	flagSet.SetOutput(stderr)
 
-	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file (mutually exclusive with --custom)")
+	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file (mutually exclusive with --custom and --custom-column)")
 	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
 	printModeStr := flagSet.String("print", "predicates", "print node parameters(EXPERIMENTAL)")
 	disallowUnknownStats := flagSet.Bool("disallow-unknown-stats", false, "error on unknown stats field")
@@ -304,7 +315,9 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	hangingIndent := flagSet.Bool("hanging-indent", false, "Enable hanging indent for wrapped lines after node-local prefixes such as [Input] and [Map]")
 
 	var custom stringList
-	flagSet.Var(&custom, "custom", "Add a custom table column definition in NAME:TEMPLATE[:ALIGNMENT[:INLINE_TYPE]] form (mutually exclusive with --custom-file)")
+	var customColumn repeatableStringList
+	flagSet.Var(&custom, "custom", "DEPRECATED: add a custom table column definition in NAME:TEMPLATE[:ALIGNMENT[:INLINE_TYPE]] form (mutually exclusive with --custom-file and --custom-column)")
+	flagSet.Var(&customColumn, "custom-column", "Add one custom table column definition as a YAML/JSON object (repeatable, mutually exclusive with --custom and --custom-file)")
 	if err := flagSet.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil
@@ -332,6 +345,21 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		_, _ = fmt.Fprintln(stderr, msg)
 		flagSet.Usage()
 		return &usageError{err: errors.New(msg)}
+	}
+	if len(customColumn) > 0 && *customFile != "" {
+		const msg = "--custom-column and --custom-file are mutually exclusive"
+		_, _ = fmt.Fprintln(stderr, msg)
+		flagSet.Usage()
+		return &usageError{err: errors.New(msg)}
+	}
+	if len(custom) > 0 && len(customColumn) > 0 {
+		const msg = "--custom and --custom-column are mutually exclusive"
+		_, _ = fmt.Fprintln(stderr, msg)
+		flagSet.Usage()
+		return &usageError{err: errors.New(msg)}
+	}
+	if len(custom) > 0 {
+		_, _ = fmt.Fprintln(stderr, "--custom is deprecated. You must migrate to --custom-column or --custom-file.")
 	}
 
 	printMode, err := parsePrintMode(*printModeStr)
@@ -414,7 +442,12 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	planNodes := qs.GetQueryPlan().GetPlanNodes()
 
 	var renderDef tableRenderDef
-	if len(custom) > 0 {
+	if len(customColumn) > 0 {
+		renderDef, err = customColumnListToTableRenderDef(customColumn)
+		if err != nil {
+			return err
+		}
+	} else if len(custom) > 0 {
 		renderDef, err = customListToTableRenderDef(custom)
 		if err != nil {
 			return err
@@ -528,14 +561,11 @@ func unmarshalAlign(t *tw.Align, bytes []byte) error {
 	return nil
 }
 
-func customFileToTableRenderDef(b []byte) (tableRenderDef, error) {
-	decodeOpts := []yaml.DecodeOption{yaml.CustomUnmarshaler(unmarshalAlign)}
+func customDecodeOptions() []yaml.DecodeOption {
+	return []yaml.DecodeOption{yaml.CustomUnmarshaler(unmarshalAlign)}
+}
 
-	var defs []plainColumnRenderDef
-	if err := yaml.UnmarshalWithOptions(b, &defs, decodeOpts...); err != nil {
-		return tableRenderDef{}, err
-	}
-
+func plainColumnRenderDefsToTableRenderDef(defs []plainColumnRenderDef) (tableRenderDef, error) {
 	var tdef tableRenderDef
 	for _, def := range defs {
 		mapFunc, err := templateMapFunc(def.Name, def.Template)
@@ -550,6 +580,28 @@ func customFileToTableRenderDef(b []byte) (tableRenderDef, error) {
 		})
 	}
 	return tdef, nil
+}
+
+func customFileToTableRenderDef(b []byte) (tableRenderDef, error) {
+	var defs []plainColumnRenderDef
+	if err := yaml.UnmarshalWithOptions(b, &defs, customDecodeOptions()...); err != nil {
+		return tableRenderDef{}, err
+	}
+
+	return plainColumnRenderDefsToTableRenderDef(defs)
+}
+
+func customColumnListToTableRenderDef(customColumns []string) (tableRenderDef, error) {
+	var defs []plainColumnRenderDef
+	for i, raw := range customColumns {
+		var def plainColumnRenderDef
+		if err := yaml.UnmarshalWithOptions([]byte(raw), &def, customDecodeOptions()...); err != nil {
+			return tableRenderDef{}, fmt.Errorf("failed to parse --custom-column[%d]: %w", i, err)
+		}
+		defs = append(defs, def)
+	}
+
+	return plainColumnRenderDefsToTableRenderDef(defs)
 }
 
 func parseInlineType(s string) (inlineType, error) {

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -26,6 +26,8 @@ import (
 	"github.com/apstndb/spannerplan/stats"
 )
 
+var customDecodeOptions = []yaml.DecodeOption{yaml.CustomUnmarshaler(unmarshalAlign)}
+
 // Main is the entry point of this command.
 // It is also used by github.com/apstndb/spannerplanviz/cmd/rendertree
 func Main() {
@@ -561,12 +563,8 @@ func unmarshalAlign(t *tw.Align, bytes []byte) error {
 	return nil
 }
 
-func customDecodeOptions() []yaml.DecodeOption {
-	return []yaml.DecodeOption{yaml.CustomUnmarshaler(unmarshalAlign)}
-}
-
 func plainColumnRenderDefsToTableRenderDef(defs []plainColumnRenderDef) (tableRenderDef, error) {
-	var tdef tableRenderDef
+	tdef := tableRenderDef{Columns: make([]columnRenderDef, 0, len(defs))}
 	for _, def := range defs {
 		mapFunc, err := templateMapFunc(def.Name, def.Template)
 		if err != nil {
@@ -584,7 +582,7 @@ func plainColumnRenderDefsToTableRenderDef(defs []plainColumnRenderDef) (tableRe
 
 func customFileToTableRenderDef(b []byte) (tableRenderDef, error) {
 	var defs []plainColumnRenderDef
-	if err := yaml.UnmarshalWithOptions(b, &defs, customDecodeOptions()...); err != nil {
+	if err := yaml.UnmarshalWithOptions(b, &defs, customDecodeOptions...); err != nil {
 		return tableRenderDef{}, err
 	}
 
@@ -592,10 +590,10 @@ func customFileToTableRenderDef(b []byte) (tableRenderDef, error) {
 }
 
 func customColumnListToTableRenderDef(customColumns []string) (tableRenderDef, error) {
-	var defs []plainColumnRenderDef
+	defs := make([]plainColumnRenderDef, 0, len(customColumns))
 	for i, raw := range customColumns {
 		var def plainColumnRenderDef
-		if err := yaml.UnmarshalWithOptions([]byte(raw), &def, customDecodeOptions()...); err != nil {
+		if err := yaml.UnmarshalWithOptions([]byte(raw), &def, customDecodeOptions...); err != nil {
 			return tableRenderDef{}, fmt.Errorf("failed to parse --custom-column[%d]: %w", i, err)
 		}
 		defs = append(defs, def)

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -40,6 +40,29 @@ func Test_customFileToTableRenderDef(t *testing.T) {
 	}
 }
 
+func Test_customColumnListToTableRenderDef(t *testing.T) {
+	trd, err := customColumnListToTableRenderDef([]string{
+		`{"name":"CPU,Time","template":"{{printf \"%s:%s,%s\" \"a\" \"b\" \"c\"}}","alignment":"RIGHT","inline":"ALWAYS"}`,
+		`{name: Operator, template: "{{.Text}}"}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(trd.Columns), 2; got != want {
+		t.Fatalf("column count = %d, want %d", got, want)
+	}
+	if got, want := trd.Columns[0].Name, "CPU,Time"; got != want {
+		t.Fatalf("name = %q, want %q", got, want)
+	}
+	if got, want := trd.Columns[0].Alignment, tw.AlignRight; got != want {
+		t.Fatalf("alignment = %v, want %v", got, want)
+	}
+	if got, want := trd.Columns[0].Inline, inlineTypeAlways; got != want {
+		t.Fatalf("inline = %q, want %q", got, want)
+	}
+}
+
 //go:embed testdata/distributed_cross_apply.yaml
 var dcaYAML []byte
 
@@ -514,6 +537,28 @@ func TestRun_UsageErrors(t *testing.T) {
 			},
 		},
 		{
+			name:        "custom-column and custom-file are mutually exclusive",
+			args:        []string{"-custom-column", `{"name":"ID","template":"{{.FormatID}}"}`, "-custom-file", "custom.yaml"},
+			wantErrText: "--custom-column and --custom-file are mutually exclusive",
+			postCheck: func(t *testing.T, stderr string, err error) {
+				t.Helper()
+				if !strings.Contains(stderr, "--custom-column and --custom-file are mutually exclusive") {
+					t.Fatalf("stderr = %q, want mutual exclusion message", stderr)
+				}
+			},
+		},
+		{
+			name:        "custom and custom-column are mutually exclusive",
+			args:        []string{"-custom", "ID:{{.FormatID}}", "-custom-column", `{"name":"Operator","template":"{{.Text}}"}`},
+			wantErrText: "--custom and --custom-column are mutually exclusive",
+			postCheck: func(t *testing.T, stderr string, err error) {
+				t.Helper()
+				if !strings.Contains(stderr, "--custom and --custom-column are mutually exclusive") {
+					t.Fatalf("stderr = %q, want mutual exclusion message", stderr)
+				}
+			},
+		},
+		{
 			name:        "invalid hanging-indent",
 			args:        []string{"-hanging-indent=broken"},
 			wantErrText: "invalid boolean value \"broken\" for -hanging-indent",
@@ -563,6 +608,22 @@ func TestRun_DeprecatedFullScanAlias(t *testing.T) {
 	}
 }
 
+func TestRun_DeprecatedCustomAlias(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := run([]string{"-custom", "ID:{{.FormatID}}:RIGHT", "-mode", "plan"}, bytes.NewReader(deleteYAML), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if !strings.Contains(stderr.String(), "--custom is deprecated. You must migrate to --custom-column or --custom-file.") {
+		t.Fatalf("stderr = %q, want deprecation warning", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "| ID |") {
+		t.Fatalf("stdout = %q, want custom output", stdout.String())
+	}
+}
+
 func TestRun_HelpReturnsNil(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -607,6 +668,31 @@ func TestRun_HangingIndent(t *testing.T) {
 	}
 	if strings.Contains(hangingLine, "|  method: Row)") {
 		t.Fatalf("hanging line = %q, want node-prefix hanging indent", hangingLine)
+	}
+}
+
+func TestRun_CustomColumn(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := run([]string{
+		"-mode", "plan",
+		"-custom-column", `{"name":"Literal,Value","template":"{{printf \"%s:%s,%s\" \"a\" \"b\" \"c\"}}"}`,
+		"-custom-column", `{"name":"Operator","template":"{{.Text}}"}`,
+	}, bytes.NewReader(dcaYAML), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run(-custom-column) error = %v", err)
+	}
+
+	if got := stderr.String(); got != "" {
+		t.Fatalf("stderr = %q, want empty", got)
+	}
+	if !strings.Contains(stdout.String(), "Literal,Value") {
+		t.Fatalf("stdout = %q, want custom column header", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "a:b,c") {
+		t.Fatalf("stdout = %q, want literal colon/comma content", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- add repeatable `--custom-column` flags that accept one YAML/JSON column definition each
- deprecate the delimiter-based `--custom` syntax and enforce mutual exclusion with the structured forms
- document the new flag and add coverage for parsing, deprecation, and inline literals containing commas/colons

## Testing
- go test -v ./...
- golangci-lint run --timeout=5m