### PR TITLE
feat: prefer hanging indent option

### DIFF
--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -424,7 +424,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		opts = append(opts, plantree.WithWrapWidth(*wrapWidth))
 	}
 	if *hangingIndent {
-		opts = append(opts, plantree.WithContinuationIndent(plantree.ContinuationIndentNodePrefix))
+		opts = append(opts, plantree.WithHangingIndent())
 	}
 
 	b, err := io.ReadAll(stdin)

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -81,7 +81,8 @@ type options struct {
 	queryplanOptions     []spannerplan.Option
 	style                treerender.Style
 	compact              bool
-	continuationIndent   ContinuationIndent
+	hangingIndent        bool
+	continuationIndent   *ContinuationIndent
 	wrapWidth            *int
 	wrapper              *tabwrap.Condition
 }
@@ -89,12 +90,19 @@ type options struct {
 type Option func(*options)
 
 // ContinuationIndent controls how wrapped continuation lines are aligned.
+//
+// Deprecated: use [WithHangingIndent] to opt into hanging indent, or omit the option
+// to keep the default tree-aligned continuation behavior.
 type ContinuationIndent int
 
 const (
 	// ContinuationIndentTree preserves the current behavior: continuation lines align only to the tree prefix.
+	//
+	// Deprecated: omit [WithHangingIndent] to keep the default tree-aligned continuation behavior.
 	ContinuationIndentTree ContinuationIndent = iota
 	// ContinuationIndentNodePrefix hangs continuation lines after a node-local prefix such as `[Input] `.
+	//
+	// Deprecated: use [WithHangingIndent].
 	ContinuationIndentNodePrefix
 )
 
@@ -129,13 +137,26 @@ func EnableCompact() Option {
 	}
 }
 
+// WithHangingIndent hangs wrapped continuation lines after a node-local prefix such as
+// `[Input] ` or `[Map] ` instead of keeping the default tree-aligned indentation.
+func WithHangingIndent() Option {
+	return func(o *options) {
+		o.hangingIndent = true
+		o.continuationIndent = nil
+	}
+}
+
 // WithContinuationIndent selects how wrapped continuation lines are aligned.
 // The default [ContinuationIndentTree] preserves the current behavior.
 // [ContinuationIndentNodePrefix] is opt-in and hangs continuation lines after a
 // node-local prefix such as `[Input] ` or `[Map] ` when present.
+//
+// Deprecated: use [WithHangingIndent] to opt into hanging indent, or omit the option
+// to keep the default tree-aligned continuation behavior.
 func WithContinuationIndent(indent ContinuationIndent) Option {
 	return func(o *options) {
-		o.continuationIndent = indent
+		o.continuationIndent = &indent
+		o.hangingIndent = indent == ContinuationIndentNodePrefix
 	}
 }
 
@@ -156,8 +177,10 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 	if o.wrapWidth != nil && *o.wrapWidth < 0 {
 		return nil, fmt.Errorf("wrap width cannot be negative: %d", *o.wrapWidth)
 	}
-	if err := validateContinuationIndent(o.continuationIndent); err != nil {
-		return nil, err
+	if o.continuationIndent != nil {
+		if err := validateContinuationIndent(*o.continuationIndent); err != nil {
+			return nil, err
+		}
 	}
 
 	root, err := buildRenderedTree(qp, nil, &o)
@@ -179,7 +202,7 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 			GetContinuationAnchor: func(n *renderedNode) string { return n.ContinuationAnchor },
 			WrapWidth:             wrapWidth,
 			WrapCondition:         o.wrapper,
-			ContinuationIndent:    mapContinuationIndent(o.continuationIndent),
+			ContinuationIndent:    mapHangingIndent(o.hangingIndent),
 		},
 	)
 	if err != nil {
@@ -270,15 +293,11 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 	return rendered, nil
 }
 
-func mapContinuationIndent(indent ContinuationIndent) treerender.ContinuationIndent {
-	switch indent {
-	case ContinuationIndentNodePrefix:
+func mapHangingIndent(enabled bool) treerender.ContinuationIndent {
+	if enabled {
 		return treerender.ContinuationIndentAnchor
-	case ContinuationIndentTree:
-		return treerender.ContinuationIndentTree
-	default:
-		panic(fmt.Sprintf("unknown ContinuationIndent: %d", indent))
 	}
+	return treerender.ContinuationIndentTree
 }
 
 func validateContinuationIndent(indent ContinuationIndent) error {

--- a/plantree/plantree_test.go
+++ b/plantree/plantree_test.go
@@ -191,7 +191,8 @@ func TestProcessPlan_NegativeWrapWidthErrors(t *testing.T) {
 
 func invalidContinuationIndentOption() Option {
 	return func(o *options) {
-		o.continuationIndent = ContinuationIndent(99)
+		indent := ContinuationIndent(99)
+		o.continuationIndent = &indent
 	}
 }
 
@@ -292,8 +293,8 @@ func hangingIndentPlan(t *testing.T) *spannerplan.QueryPlan {
 	return qp
 }
 
-func TestProcessPlan_ContinuationIndentNodePrefix(t *testing.T) {
-	opts := append(currentOptions(), WithWrapWidth(21), WithContinuationIndent(ContinuationIndentNodePrefix))
+func TestProcessPlan_HangingIndent(t *testing.T) {
+	opts := append(currentOptions(), WithWrapWidth(21), WithHangingIndent())
 	rows, err := ProcessPlan(hangingIndentPlan(t), opts...)
 	if err != nil {
 		t.Fatalf("ProcessPlan() error = %v", err)
@@ -311,6 +312,28 @@ func TestProcessPlan_ContinuationIndentNodePrefix(t *testing.T) {
 		NodeText: got.NodeText,
 	}); diff != "" {
 		t.Fatalf("row 1 mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestProcessPlan_DeprecatedContinuationIndentNodePrefix(t *testing.T) {
+	withDeprecated, err := ProcessPlan(hangingIndentPlan(t), append(currentOptions(),
+		WithWrapWidth(21),
+		WithContinuationIndent(ContinuationIndentNodePrefix),
+	)...)
+	if err != nil {
+		t.Fatalf("ProcessPlan(deprecated option) error = %v", err)
+	}
+
+	withHanging, err := ProcessPlan(hangingIndentPlan(t), append(currentOptions(),
+		WithWrapWidth(21),
+		WithHangingIndent(),
+	)...)
+	if err != nil {
+		t.Fatalf("ProcessPlan(WithHangingIndent) error = %v", err)
+	}
+
+	if diff := cmp.Diff(withHanging, withDeprecated); diff != "" {
+		t.Fatalf("deprecated continuation-indent option mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -250,7 +250,7 @@ func processTree(planNodes []*sppb.PlanNode, format Format, opts options) ([]pla
 		plantreeOpts = append(plantreeOpts, plantree.WithWrapWidth(opts.wrapWidth))
 	}
 	if opts.hangingIndent {
-		plantreeOpts = append(plantreeOpts, plantree.WithContinuationIndent(plantree.ContinuationIndentNodePrefix))
+		plantreeOpts = append(plantreeOpts, plantree.WithHangingIndent())
 	}
 
 	return plantree.ProcessPlan(qp, plantreeOpts...)

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -387,7 +387,7 @@ func TestRenderTreeTable_InputValidation(t *testing.T) {
 	}
 }
 
-func TestRenderTreeTableWithOptions_ContinuationIndentNodePrefix(t *testing.T) {
+func TestRenderTreeTableWithOptions_HangingIndent(t *testing.T) {
 	input := loadWrappedPlan(t)
 	stats, _, err := queryplan.ExtractQueryPlan([]byte(input))
 	if err != nil {


### PR DESCRIPTION
## Summary
- add `plantree.WithHangingIndent()` as the preferred public API for opt-in hanging indent
- keep `WithContinuationIndent(...)` and `ContinuationIndent*` as deprecated compatibility paths
- switch `reference` and `rendertree` to the new public option and add compatibility coverage

## Testing
- go test -v ./...
- golangci-lint run --timeout=5m