### PR TITLE
fix: keep hanging-indent child guides

### DIFF
--- a/internal/treerender/treerender.go
+++ b/internal/treerender/treerender.go
@@ -179,17 +179,6 @@ func renderTree[T any](
 		if node == nil {
 			return
 		}
-		text := getText(node)
-		anchor := ""
-		if opts.wrapWidth > 0 && opts.continuationIndent == ContinuationIndentAnchor && opts.getContinuationAnchor != nil {
-			anchor = opts.getContinuationAnchor(node)
-		}
-		rows = append(rows, renderRow(ancestorPrefix, text, anchor, isLast, isRoot, sw, opts.wrapWidth, opts.wrapCondition, opts.continuationIndent))
-
-		next := ancestorPrefix
-		if !isRoot {
-			next = ancestorPrefix + sw.segment(!isLast)
-		}
 		children := getChildren(node)
 		lastIdx := -1
 		for i := len(children) - 1; i >= 0; i-- {
@@ -197,6 +186,28 @@ func renderTree[T any](
 				lastIdx = i
 				break
 			}
+		}
+		text := getText(node)
+		anchor := ""
+		if opts.wrapWidth > 0 && opts.continuationIndent == ContinuationIndentAnchor && opts.getContinuationAnchor != nil {
+			anchor = opts.getContinuationAnchor(node)
+		}
+		rows = append(rows, renderRow(
+			ancestorPrefix,
+			text,
+			anchor,
+			lastIdx >= 0,
+			isLast,
+			isRoot,
+			sw,
+			opts.wrapWidth,
+			opts.wrapCondition,
+			opts.continuationIndent,
+		))
+
+		next := ancestorPrefix
+		if !isRoot {
+			next = ancestorPrefix + sw.segment(!isLast)
 		}
 		for i, child := range children {
 			if child == nil {
@@ -212,6 +223,7 @@ func renderTree[T any](
 
 func renderRow(
 	ancestorPrefix, text, anchor string,
+	hasChildren bool,
 	isLast, isRoot bool,
 	sw styleWidths,
 	wrapWidth int,
@@ -226,7 +238,7 @@ func renderRow(
 	}
 
 	firstPrefix, continuationPrefix := rowPrefixes(ancestorPrefix, isLast, isRoot, sw)
-	treeLines, nodeLines := wrapRowLines(text, anchor, firstPrefix, continuationPrefix, wrapWidth, wrapCondition, continuationIndent)
+	treeLines, nodeLines := wrapRowLines(text, anchor, firstPrefix, continuationPrefix, hasChildren, sw.style.EdgeLink, wrapWidth, wrapCondition, continuationIndent)
 	return Row{
 		TreePart: strings.Join(treeLines, "\n"),
 		NodeText: strings.Join(nodeLines, "\n"),
@@ -243,6 +255,8 @@ func rowPrefixes(ancestorPrefix string, isLast, isRoot bool, sw styleWidths) (fi
 
 func wrapRowLines(
 	text, anchor, firstPrefix, continuationPrefix string,
+	hasChildren bool,
+	childGuide string,
 	wrapWidth int,
 	wrapCondition *tabwrap.Condition,
 	continuationIndent ContinuationIndent,
@@ -267,12 +281,32 @@ func wrapRowLines(
 	treeLines[0] = firstPrefix
 	continuationTree := continuationPrefix
 	if anchorWidth > 0 {
-		continuationTree += strings.Repeat(" ", anchorWidth)
+		continuationTree += hangingIndentPadding(anchorWidth, hasChildren, childGuide, wrapCondition)
 	}
 	for i := 1; i < len(treeLines); i++ {
 		treeLines[i] = continuationTree
 	}
 	return treeLines, nodeLines
+}
+
+func hangingIndentPadding(anchorWidth int, hasChildren bool, childGuide string, wrapCondition *tabwrap.Condition) string {
+	if anchorWidth <= 0 {
+		return ""
+	}
+	if !hasChildren || childGuide == "" {
+		return strings.Repeat(" ", anchorWidth)
+	}
+
+	guide := childGuide
+	if guideWidth := wrapCondition.StringWidth(guide); guideWidth > anchorWidth {
+		guide = wrapCondition.Truncate(guide, anchorWidth, "")
+	}
+	if guide == "" {
+		return strings.Repeat(" ", anchorWidth)
+	}
+
+	guideWidth := wrapCondition.StringWidth(guide)
+	return guide + strings.Repeat(" ", max(0, anchorWidth-guideWidth))
 }
 
 func validateContinuationIndent(continuationIndent ContinuationIndent) error {

--- a/internal/treerender/treerender.go
+++ b/internal/treerender/treerender.go
@@ -298,14 +298,14 @@ func hangingIndentPadding(anchorWidth int, hasChildren bool, childGuide string, 
 	}
 
 	guide := childGuide
-	if guideWidth := wrapCondition.StringWidth(guide); guideWidth > anchorWidth {
-		guide = wrapCondition.Truncate(guide, anchorWidth, "")
-	}
-	if guide == "" {
-		return strings.Repeat(" ", anchorWidth)
-	}
-
 	guideWidth := wrapCondition.StringWidth(guide)
+	if guideWidth > anchorWidth {
+		guide = wrapCondition.Truncate(guide, anchorWidth, "")
+		if guide == "" {
+			return strings.Repeat(" ", anchorWidth)
+		}
+		guideWidth = wrapCondition.StringWidth(guide)
+	}
 	return guide + strings.Repeat(" ", max(0, anchorWidth-guideWidth))
 }
 

--- a/internal/treerender/treerender_test.go
+++ b/internal/treerender/treerender_test.go
@@ -180,6 +180,82 @@ func TestRenderTreeWithOptions_HangingIndentAnchor(t *testing.T) {
 	}
 }
 
+func TestRenderTreeWithOptions_HangingIndentAnchorKeepsChildGuide(t *testing.T) {
+	tests := map[string]*Node{
+		"non-last": {
+			Text: "root",
+			Children: []*Node{
+				{
+					Text: "[Input] Batch Scan <Row>",
+					Children: []*Node{
+						{Text: "leaf"},
+					},
+				},
+				{Text: "tail"},
+			},
+		},
+		"last": {
+			Text: "root",
+			Children: []*Node{
+				{Text: "head"},
+				{
+					Text: "[Map] Local Distributed Union <Row>",
+					Children: []*Node{
+						{Text: "leaf"},
+					},
+				},
+			},
+		},
+	}
+
+	wants := map[string][]Row{
+		"non-last": {
+			{TreePart: "", NodeText: "root"},
+			{TreePart: "+- \n|  |       ", NodeText: "[Input] Batch Scan\n <Row>"},
+			{TreePart: "|  +- ", NodeText: "leaf"},
+			{TreePart: "+- ", NodeText: "tail"},
+		},
+		"last": {
+			{TreePart: "", NodeText: "root"},
+			{TreePart: "+- ", NodeText: "head"},
+			{TreePart: "+- \n   |     \n   |     ", NodeText: "[Map] Local Distri\nbuted Union \n<Row>"},
+			{TreePart: "   +- ", NodeText: "leaf"},
+		},
+	}
+
+	for name, root := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := RenderTreeWithOptions(
+				root,
+				DefaultStyle(),
+				func(n *Node) string { return n.Text },
+				func(n *Node) []*Node { return n.Children },
+				RenderOptions[Node]{
+					GetContinuationAnchor: func(n *Node) string {
+						switch {
+						case strings.HasPrefix(n.Text, "[Input] "):
+							return "[Input] "
+						case strings.HasPrefix(n.Text, "[Map] "):
+							return "[Map] "
+						default:
+							return ""
+						}
+					},
+					WrapWidth:          21,
+					WrapCondition:      tabwrap.NewCondition(),
+					ContinuationIndent: ContinuationIndentAnchor,
+				},
+			)
+			if err != nil {
+				t.Fatalf("RenderTreeWithOptions() error = %v", err)
+			}
+			if diff := cmp.Diff(wants[name], got); diff != "" {
+				t.Fatalf("RenderTreeWithOptions() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestRenderTreeWithOptions_TinyBudgetKeepsUTF8Valid(t *testing.T) {
 	root := &Node{
 		Text: "root",

--- a/internal/treerender/treerender_test.go
+++ b/internal/treerender/treerender_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	"github.com/apstndb/go-tabwrap"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -162,7 +161,7 @@ func TestRenderTreeWithOptions_HangingIndentAnchor(t *testing.T) {
 				return ""
 			},
 			WrapWidth:          21,
-			WrapCondition:      tabwrap.NewCondition(),
+			WrapCondition:      defaultWrapCondition,
 			ContinuationIndent: ContinuationIndentAnchor,
 		},
 	)
@@ -218,7 +217,7 @@ func TestRenderTreeWithOptions_HangingIndentAnchorKeepsChildGuide(t *testing.T) 
 		"last": {
 			{TreePart: "", NodeText: "root"},
 			{TreePart: "+- ", NodeText: "head"},
-			{TreePart: "+- \n   |     \n   |     ", NodeText: "[Map] Local Distri\nbuted Union \n<Row>"},
+			{TreePart: "+- \n   |     \n   |     ", NodeText: "[Map] Local Distri\nbuted Union\n<Row>"},
 			{TreePart: "   +- ", NodeText: "leaf"},
 		},
 	}
@@ -242,7 +241,7 @@ func TestRenderTreeWithOptions_HangingIndentAnchorKeepsChildGuide(t *testing.T) 
 						}
 					},
 					WrapWidth:          21,
-					WrapCondition:      tabwrap.NewCondition(),
+					WrapCondition:      defaultWrapCondition,
 					ContinuationIndent: ContinuationIndentAnchor,
 				},
 			)

--- a/plantree/plantree_test.go
+++ b/plantree/plantree_test.go
@@ -293,6 +293,47 @@ func hangingIndentPlan(t *testing.T) *spannerplan.QueryPlan {
 	return qp
 }
 
+func hangingIndentChildGuidePlan(t *testing.T) *spannerplan.QueryPlan {
+	t.Helper()
+
+	qp, err := spannerplan.New([]*sppb.PlanNode{
+		{
+			Index:       0,
+			DisplayName: "Cross Apply",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 1},
+				{ChildIndex: 2, Type: "Map"},
+			},
+		},
+		{
+			Index:       1,
+			DisplayName: "Batch Scan",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 3},
+			},
+			Metadata: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"execution_method": structpb.NewStringValue("Row"),
+			}},
+		},
+		{
+			Index:       2,
+			DisplayName: "Serialize Result",
+			Kind:        sppb.PlanNode_RELATIONAL,
+		},
+		{
+			Index:       3,
+			DisplayName: "Filter Scan",
+			Kind:        sppb.PlanNode_RELATIONAL,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return qp
+}
+
 func TestProcessPlan_HangingIndent(t *testing.T) {
 	opts := append(currentOptions(), WithWrapWidth(21), WithHangingIndent())
 	rows, err := ProcessPlan(hangingIndentPlan(t), opts...)
@@ -304,6 +345,28 @@ func TestProcessPlan_HangingIndent(t *testing.T) {
 	want := RowWithPredicates{
 		ID:       1,
 		TreePart: "+- \n|          ",
+		NodeText: "[Input] Batch Scan\n <Row>",
+	}
+	if diff := cmp.Diff(want, RowWithPredicates{
+		ID:       got.ID,
+		TreePart: got.TreePartString(),
+		NodeText: got.NodeText,
+	}); diff != "" {
+		t.Fatalf("row 1 mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestProcessPlan_HangingIndentKeepsChildGuide(t *testing.T) {
+	opts := append(currentOptions(), WithWrapWidth(21), WithHangingIndent())
+	rows, err := ProcessPlan(hangingIndentChildGuidePlan(t), opts...)
+	if err != nil {
+		t.Fatalf("ProcessPlan() error = %v", err)
+	}
+
+	got := rowByID(t, rows, 1)
+	want := RowWithPredicates{
+		ID:       1,
+		TreePart: "+- \n|  |       ",
 		NodeText: "[Input] Batch Scan\n <Row>",
 	}
 	if diff := cmp.Diff(want, RowWithPredicates{


### PR DESCRIPTION
## Summary
- preserve descendant guide lines on wrapped hanging-indent continuation lines
- keep the extra hanging-indent padding while retaining the child guide when a wrapped node has descendants
- add regression coverage in internal/treerender and plantree

## Testing
- go test -v ./...
- golangci-lint run --timeout=5m