### PR TITLE
chore: remove lox dependency

### DIFF
--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"cmp"
 	"errors"
 	"flag"
 	"fmt"
@@ -14,7 +15,6 @@ import (
 	"text/template"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
-	"github.com/apstndb/lox"
 	"github.com/goccy/go-yaml"
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/tablewriter/renderer"
@@ -196,6 +196,14 @@ var secsRe = regexp.MustCompile(`secs$`)
 
 func secsToS(v any) string {
 	return secsRe.ReplaceAllString(fmt.Sprint(v), "s")
+}
+
+func sortedChildLinkEntries(m map[string][]*spannerplan.ResolvedChildLink) []lo.Entry[string, []*spannerplan.ResolvedChildLink] {
+	entries := lo.Entries(m)
+	slices.SortFunc(entries, func(a, b lo.Entry[string, []*spannerplan.ResolvedChildLink]) int {
+		return cmp.Compare(a.Key, b.Key)
+	})
+	return entries
 }
 
 var (
@@ -712,7 +720,7 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 		}
 
 		i := 0
-		for _, t := range lox.EntriesSortedByKey(row.ChildLinks) {
+		for _, t := range sortedChildLinkEntries(row.ChildLinks) {
 			typ, childLinks := t.Key, t.Value
 			if printMode != PrintFull && typ == "" {
 				continue

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,10 @@ require (
 	cloud.google.com/go/spanner v1.48.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/apstndb/go-tabwrap v0.1.3
-	github.com/apstndb/lox v0.0.0-20230530141045-98c1efebcde8
 	github.com/goccy/go-yaml v1.17.1
 	github.com/google/go-cmp v0.5.9
 	github.com/olekukonko/tablewriter v1.0.9
-	github.com/samber/lo v1.47.0
+	github.com/samber/lo v1.53.0
 	google.golang.org/protobuf v1.33.0
 )
 
@@ -27,7 +26,6 @@ require (
 	github.com/olekukonko/errors v1.1.0 // indirect
 	github.com/olekukonko/ll v0.0.9 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/apstndb/go-tabwrap v0.1.3 h1:5lO2M7Zl5NOus4cve0tu58j3txnNRAEd9MAsFitDCQw=
 github.com/apstndb/go-tabwrap v0.1.3/go.mod h1:duMNZZhNjqj/VXR2AXJN1MWko2RyIytSP1NJyhMmUV4=
-github.com/apstndb/lox v0.0.0-20230530141045-98c1efebcde8 h1:xwpcb2pS5AsZZwAlmRjD4oYcJruN5mZF4J67Qv/qFHs=
-github.com/apstndb/lox v0.0.0-20230530141045-98c1efebcde8/go.mod h1:BkhLxNZ6Ql4FyP43VFrNyq+B4uf5J02RYRlemBCrazI=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
@@ -35,10 +33,8 @@ github.com/olekukonko/tablewriter v1.0.9 h1:XGwRsYLC2bY7bNd93Dk51bcPZksWZmLYuaTH
 github.com/olekukonko/tablewriter v1.0.9/go.mod h1:5c+EBPeSqvXnLLgkm9isDdzR3wjfBkHR9Nhfp3NWrzo=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
-github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
+github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
+github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
 golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -7,7 +7,6 @@ import (
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/go-tabwrap"
-	"github.com/apstndb/lox"
 	"github.com/samber/lo"
 
 	"github.com/apstndb/spannerplan"
@@ -73,7 +72,7 @@ func (r RowWithPredicates) TreePartLines() []string {
 }
 
 func (r RowWithPredicates) FormatID() string {
-	return lox.IfOrEmpty(len(r.Predicates) != 0, "*") + strconv.Itoa(int(r.ID))
+	return lo.Ternary(len(r.Predicates) != 0, "*", "") + strconv.Itoa(int(r.ID))
 }
 
 type options struct {
@@ -242,7 +241,7 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 
 	node := qp.GetNodeByChildLink(link)
 	linkType := qp.GetLinkType(link)
-	continuationAnchor := lox.IfOrEmpty(linkType != "", "["+linkType+"]"+sep)
+	continuationAnchor := lo.Ternary(linkType != "", "["+linkType+"]"+sep, "")
 	nodeText := continuationAnchor + spannerplan.NodeTitle(node, opts.queryplanOptions...)
 
 	var predicates []string
@@ -256,9 +255,11 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 			qp.GetNodeByChildLink(cl).GetShortRepresentation().GetDescription()))
 	}
 
-	resolvedChildLinks := lox.MapWithoutIndex(node.GetChildLinks(), qp.ResolveChildLink)
+	resolvedChildLinks := lo.Map(node.GetChildLinks(), func(item *sppb.PlanNode_ChildLink, _ int) *spannerplan.ResolvedChildLink {
+		return qp.ResolveChildLink(item)
+	})
 
-	scalarChildLinks := lox.FilterWithoutIndex(resolvedChildLinks, func(item *spannerplan.ResolvedChildLink) bool {
+	scalarChildLinks := lo.Filter(resolvedChildLinks, func(item *spannerplan.ResolvedChildLink, _ int) bool {
 		return item.Child.GetKind() == sppb.PlanNode_SCALAR
 	})
 

--- a/queryplan.go
+++ b/queryplan.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
-	"github.com/apstndb/lox"
 	"github.com/samber/lo"
 )
 
@@ -262,7 +261,7 @@ func NodeTitle(node *sppb.PlanNode, opts ...Option) string {
 		opt(&o)
 	}
 
-	sep := lox.IfOrEmpty(!o.compact, " ")
+	sep := lo.Ternary(!o.compact, " ", "")
 
 	metadataFields := node.GetMetadata().GetFields()
 
@@ -285,8 +284,11 @@ func NodeTitle(node *sppb.PlanNode, opts ...Option) string {
 			"on "+target, ""),
 	)
 
-	executionMethodPart := lox.IfOrEmpty(o.executionMethodFormat == ExecutionMethodFormatAngle && len(executionMethod) > 0,
-		"<"+executionMethod+">")
+	executionMethodPart := lo.Ternary(
+		o.executionMethodFormat == ExecutionMethodFormatAngle && len(executionMethod) > 0,
+		"<"+executionMethod+">",
+		"",
+	)
 
 	var labels []string
 	var fields []string


### PR DESCRIPTION
## Summary
- replace the remaining lox helpers with lo or standard-library equivalents
- add a local sorted entry helper for child-link rendering instead of depending on lox
- upgrade github.com/samber/lo to v1.53.0 and remove github.com/apstndb/lox from module dependencies

## Testing
- go test -v ./...
- golangci-lint run --timeout=5m