### PR TITLE
feat: add reference render config

### DIFF
--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -1,5 +1,10 @@
 // Package reference provides a reference implementation for rendering
 // Spanner query plans as ASCII tables with various formatting options.
+//
+// Go callers should prefer [RenderTreeTableWithOptions] with functional options.
+// Cross-language integrations, such as WebAssembly or JavaScript wrappers that
+// start from JSON-like configuration, can use [RenderTreeTableWithConfig] and
+// [RenderConfig].
 package reference
 
 import (
@@ -32,6 +37,21 @@ const (
 type options struct {
 	wrapWidth     int
 	hangingIndent bool
+}
+
+// RenderConfig configures optional rendering behavior using serialization-friendly fields.
+//
+// Use this type for cross-language integrations that start from JSON-like configuration,
+// such as WebAssembly or JavaScript callers. Go callers can continue to use functional
+// [Option] values with [RenderTreeTableWithOptions].
+type RenderConfig struct {
+	// WrapWidth sets the maximum total rendered line width, including the tree prefix.
+	// A value of 0 disables wrapping. Negative values make [RenderTreeTableWithConfig] return an error.
+	WrapWidth int `json:"wrapWidth,omitempty"`
+
+	// HangingIndent hangs wrapped continuation lines after node-local prefixes such as
+	// `[Input] ` and `[Map] ` instead of keeping the default tree-aligned indentation.
+	HangingIndent bool `json:"hangingIndent,omitempty"`
 }
 
 // Option configures optional rendering behavior for [RenderTreeTableWithOptions].
@@ -75,6 +95,12 @@ func RenderTreeTable(planNodes []*sppb.PlanNode, mode RenderMode, format Format,
 	return RenderTreeTableWithOptions(planNodes, mode, format, WithWrapWidth(wrapWidth))
 }
 
+// RenderTreeTableWithConfig renders Spanner plan nodes as an ASCII table using
+// serialization-friendly rendering configuration.
+func RenderTreeTableWithConfig(planNodes []*sppb.PlanNode, mode RenderMode, format Format, config RenderConfig) (string, error) {
+	return renderTreeTable(planNodes, mode, format, optionsFromConfig(config))
+}
+
 // RenderTreeTableWithOptions renders Spanner plan nodes as an ASCII table with optional rendering configuration.
 func RenderTreeTableWithOptions(planNodes []*sppb.PlanNode, mode RenderMode, format Format, opts ...Option) (string, error) {
 	o := options{}
@@ -85,6 +111,17 @@ func RenderTreeTableWithOptions(planNodes []*sppb.PlanNode, mode RenderMode, for
 		opt(&o)
 	}
 
+	return renderTreeTable(planNodes, mode, format, o)
+}
+
+func optionsFromConfig(config RenderConfig) options {
+	return options{
+		wrapWidth:     config.WrapWidth,
+		hangingIndent: config.HangingIndent,
+	}
+}
+
+func renderTreeTable(planNodes []*sppb.PlanNode, mode RenderMode, format Format, o options) (string, error) {
 	// Validate input parameters
 	if len(planNodes) == 0 {
 		return "", fmt.Errorf("planNodes cannot be empty")

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -428,6 +428,74 @@ func TestRenderTreeTableWithOptions_HangingIndent(t *testing.T) {
 	}
 }
 
+func TestRenderTreeTableWithConfig(t *testing.T) {
+	input := loadWrappedPlan(t)
+	stats, _, err := queryplan.ExtractQueryPlan([]byte(input))
+	if err != nil {
+		t.Fatalf("Failed to extract query plan: %v", err)
+	}
+	planNodes := stats.GetQueryPlan().GetPlanNodes()
+
+	tests := []struct {
+		name   string
+		config RenderConfig
+		opts   []Option
+	}{
+		{
+			name:   "zero value matches no options",
+			config: RenderConfig{},
+		},
+		{
+			name:   "wrap width matches WithWrapWidth",
+			config: RenderConfig{WrapWidth: 50},
+			opts:   []Option{WithWrapWidth(50)},
+		},
+		{
+			name:   "hanging indent matches WithHangingIndent",
+			config: RenderConfig{HangingIndent: true},
+			opts:   []Option{WithHangingIndent()},
+		},
+		{
+			name:   "wrap width and hanging indent match options",
+			config: RenderConfig{WrapWidth: 50, HangingIndent: true},
+			opts:   []Option{WithWrapWidth(50), WithHangingIndent()},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := RenderTreeTableWithConfig(planNodes, RenderModePlan, FormatCurrent, tc.config)
+			if err != nil {
+				t.Fatalf("RenderTreeTableWithConfig() error = %v", err)
+			}
+
+			want, err := RenderTreeTableWithOptions(planNodes, RenderModePlan, FormatCurrent, tc.opts...)
+			if err != nil {
+				t.Fatalf("RenderTreeTableWithOptions() error = %v", err)
+			}
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatalf("RenderTreeTableWithConfig() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRenderTreeTableWithConfig_NegativeWrapWidth(t *testing.T) {
+	_, err := RenderTreeTableWithConfig(
+		[]*sppb.PlanNode{{}},
+		RenderModeAuto,
+		FormatCurrent,
+		RenderConfig{WrapWidth: -1},
+	)
+	if err == nil {
+		t.Fatal("RenderTreeTableWithConfig() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "wrapWidth cannot be negative") {
+		t.Fatalf("RenderTreeTableWithConfig() error = %q, want wrapWidth cannot be negative", err)
+	}
+}
+
 func TestRenderTreeTableWithOptions_NilOption(t *testing.T) {
 	input := loadWrappedPlan(t)
 	stats, _, err := queryplan.ExtractQueryPlan([]byte(input))


### PR DESCRIPTION
## Summary
- add `reference.RenderConfig` with JSON-friendly `wrapWidth` and `hangingIndent` fields
- add `reference.RenderTreeTableWithConfig` for serialized/cross-language configuration flows
- share rendering logic with the existing functional-options API and add equivalence tests

Closes #28

## Testing
- go test -v ./plantree/reference ./...
- golangci-lint run --timeout=5m