### PR TITLE
docs: add browser and wasm embedding guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ parses `mode` and `format` strings with `reference.ParseRenderMode(...)` and
 `{error: string}`.
 
 ```bash
-GOOS=js GOARCH=wasm go build -o dist/spannerplan.wasm ./examples/wasm/render
+GOOS=js GOARCH=wasm go build -o ./spannerplan.wasm ./examples/wasm/render
 ```
 
 ```js

--- a/README.md
+++ b/README.md
@@ -2,6 +2,42 @@
 
 Spanner QueryPlan manipulation module.
 
+## Browser and WASM embedding
+
+For browser-facing renderers, use `github.com/apstndb/spannerplan/plantree/reference`
+as the recommended high-level entrypoint.
+
+- Go callers should prefer `reference.RenderTreeTableWithOptions(...)`.
+- Serialized or cross-language callers such as WebAssembly or JavaScript wrappers
+  should prefer `reference.RenderTreeTableWithConfig(...)` with
+  `reference.RenderConfig`.
+
+A minimal `syscall/js` wrapper lives in `examples/wasm/render`. It accepts a
+Spanner query plan as JSON text or a JavaScript object containing `planNodes`,
+parses `mode` and `format` strings with `reference.ParseRenderMode(...)` and
+`reference.ParseFormat(...)`, decodes render settings into
+`reference.RenderConfig`, and returns either `{output: string}` or
+`{error: string}`.
+
+```bash
+GOOS=js GOARCH=wasm go build -o dist/spannerplan.wasm ./examples/wasm/render
+```
+
+```js
+const result = globalThis.spannerplanRenderTreeTable(
+  queryPlanJson,
+  "AUTO",
+  "CURRENT",
+  {wrapWidth: 80, hangingIndent: true},
+)
+
+if (result.error) {
+  throw new Error(result.error)
+}
+
+console.log(result.output)
+```
+
 ## Sub-projects
 
 - [rendertree](./cmd/rendertree)

--- a/examples/wasm/render/main.go
+++ b/examples/wasm/render/main.go
@@ -141,7 +141,7 @@ func jsonBytes(v js.Value) ([]byte, error) {
 	return []byte(stringified), nil
 }
 
-func stringifyJSON(v js.Value) (_ string, err error) {
+func stringifyJSON(v js.Value) (jsonStr string, err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			err = fmt.Errorf("failed to stringify JavaScript value: %v", recovered)

--- a/examples/wasm/render/main.go
+++ b/examples/wasm/render/main.go
@@ -1,0 +1,127 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"syscall/js"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/apstndb/spannerplan/plantree/reference"
+)
+
+var (
+	unmarshalQueryPlan = protojson.UnmarshalOptions{DiscardUnknown: true}
+	renderTreeTableJS  js.Func
+)
+
+func main() {
+	renderTreeTableJS = js.FuncOf(renderTreeTable)
+	js.Global().Set("spannerplanRenderTreeTable", renderTreeTableJS)
+	select {}
+}
+
+func renderTreeTable(this js.Value, args []js.Value) any {
+	output, err := renderTreeTableFromArgs(args)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+	return map[string]any{"output": output}
+}
+
+func renderTreeTableFromArgs(args []js.Value) (string, error) {
+	if len(args) == 0 || args[0].IsUndefined() || args[0].IsNull() {
+		return "", fmt.Errorf("query plan argument is required")
+	}
+
+	plan, err := decodeQueryPlan(args[0])
+	if err != nil {
+		return "", err
+	}
+
+	modeStr, err := optionalStringArg(args, 1, "AUTO", "mode")
+	if err != nil {
+		return "", err
+	}
+	mode, err := reference.ParseRenderMode(modeStr)
+	if err != nil {
+		return "", err
+	}
+
+	formatStr, err := optionalStringArg(args, 2, "CURRENT", "format")
+	if err != nil {
+		return "", err
+	}
+	format, err := reference.ParseFormat(formatStr)
+	if err != nil {
+		return "", err
+	}
+
+	config, err := decodeRenderConfig(args, 3)
+	if err != nil {
+		return "", err
+	}
+
+	return reference.RenderTreeTableWithConfig(plan.GetPlanNodes(), mode, format, config)
+}
+
+func decodeQueryPlan(v js.Value) (*sppb.QueryPlan, error) {
+	raw, err := jsonBytes(v)
+	if err != nil {
+		return nil, fmt.Errorf("decode query plan argument: %w", err)
+	}
+
+	var plan sppb.QueryPlan
+	if err := unmarshalQueryPlan.Unmarshal(raw, &plan); err != nil {
+		return nil, fmt.Errorf("decode query plan JSON: %w", err)
+	}
+	if len(plan.GetPlanNodes()) == 0 {
+		return nil, fmt.Errorf("query plan JSON must contain planNodes")
+	}
+	return &plan, nil
+}
+
+func decodeRenderConfig(args []js.Value, index int) (reference.RenderConfig, error) {
+	if len(args) <= index || args[index].IsUndefined() || args[index].IsNull() {
+		return reference.RenderConfig{}, nil
+	}
+
+	raw, err := jsonBytes(args[index])
+	if err != nil {
+		return reference.RenderConfig{}, fmt.Errorf("decode config argument: %w", err)
+	}
+
+	var config reference.RenderConfig
+	if err := json.Unmarshal(raw, &config); err != nil {
+		return reference.RenderConfig{}, fmt.Errorf("decode config JSON: %w", err)
+	}
+	return config, nil
+}
+
+func optionalStringArg(args []js.Value, index int, fallback, name string) (string, error) {
+	if len(args) <= index || args[index].IsUndefined() || args[index].IsNull() {
+		return fallback, nil
+	}
+	if args[index].Type() != js.TypeString {
+		return "", fmt.Errorf("%s must be a string", name)
+	}
+	return args[index].String(), nil
+}
+
+func jsonBytes(v js.Value) ([]byte, error) {
+	if v.Type() == js.TypeString {
+		return []byte(v.String()), nil
+	}
+	if v.Type() != js.TypeObject {
+		return nil, fmt.Errorf("expected JSON string or object, got %s", v.Type())
+	}
+
+	stringified := js.Global().Get("JSON").Call("stringify", v)
+	if stringified.Type() != js.TypeString {
+		return nil, fmt.Errorf("failed to stringify JavaScript value")
+	}
+	return []byte(stringified.String()), nil
+}

--- a/examples/wasm/render/main.go
+++ b/examples/wasm/render/main.go
@@ -24,7 +24,15 @@ func main() {
 	select {}
 }
 
-func renderTreeTable(this js.Value, args []js.Value) any {
+func renderTreeTable(this js.Value, args []js.Value) (result any) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result = map[string]any{
+				"error": fmt.Sprintf("panic while rendering query plan: %v", recovered),
+			}
+		}
+	}()
+
 	output, err := renderTreeTableFromArgs(args)
 	if err != nil {
 		return map[string]any{"error": err.Error()}
@@ -119,9 +127,30 @@ func jsonBytes(v js.Value) ([]byte, error) {
 		return nil, fmt.Errorf("expected JSON string or object, got %s", v.Type())
 	}
 
+	uint8Array := js.Global().Get("Uint8Array")
+	if uint8Array.Truthy() && v.InstanceOf(uint8Array) {
+		b := make([]byte, v.Get("length").Int())
+		js.CopyBytesToGo(b, v)
+		return b, nil
+	}
+
+	stringified, err := stringifyJSON(v)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(stringified), nil
+}
+
+func stringifyJSON(v js.Value) (_ string, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("failed to stringify JavaScript value: %v", recovered)
+		}
+	}()
+
 	stringified := js.Global().Get("JSON").Call("stringify", v)
 	if stringified.Type() != js.TypeString {
-		return nil, fmt.Errorf("failed to stringify JavaScript value")
+		return "", fmt.Errorf("failed to stringify JavaScript value")
 	}
-	return []byte(stringified.String()), nil
+	return stringified.String(), nil
 }

--- a/examples/wasm/render/main.go
+++ b/examples/wasm/render/main.go
@@ -3,8 +3,10 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"syscall/js"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
@@ -103,7 +105,7 @@ func decodeRenderConfig(args []js.Value, index int) (reference.RenderConfig, err
 	}
 
 	var config reference.RenderConfig
-	if err := json.Unmarshal(raw, &config); err != nil {
+	if err := unmarshalStrictJSON(raw, &config); err != nil {
 		return reference.RenderConfig{}, fmt.Errorf("decode config JSON: %w", err)
 	}
 	return config, nil
@@ -153,4 +155,20 @@ func stringifyJSON(v js.Value) (jsonStr string, err error) {
 		return "", fmt.Errorf("failed to stringify JavaScript value")
 	}
 	return stringified.String(), nil
+}
+
+func unmarshalStrictJSON(raw []byte, dst any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing JSON")
+		}
+		return err
+	}
+	return nil
 }

--- a/examples/wasm/render/main_stub.go
+++ b/examples/wasm/render/main_stub.go
@@ -1,0 +1,6 @@
+//go:build !js || !wasm
+
+package main
+
+// main keeps this example buildable under ./... on non-js/wasm platforms.
+func main() {}

--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -8,8 +8,9 @@
 //
 // For browser or WebAssembly embeddings, this package is the recommended
 // high-level renderer entrypoint: decode serialized query plan JSON into
-// sppb.QueryPlan with protojson, parse string inputs with [ParseRenderMode] and
-// [ParseFormat], then call [RenderTreeTableWithConfig] with plan.GetPlanNodes().
+// spannerpb.QueryPlan with protojson, parse string inputs with [ParseRenderMode]
+// and [ParseFormat], then call [RenderTreeTableWithConfig] with
+// plan.GetPlanNodes().
 // The repository's examples/wasm/render example shows a small syscall/js wrapper
 // with that flow.
 package reference

--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -5,6 +5,13 @@
 // Cross-language integrations, such as WebAssembly or JavaScript wrappers that
 // start from JSON-like configuration, can use [RenderTreeTableWithConfig] and
 // [RenderConfig].
+//
+// For browser or WebAssembly embeddings, this package is the recommended
+// high-level renderer entrypoint: decode serialized query plan JSON into
+// sppb.QueryPlan with protojson, parse string inputs with [ParseRenderMode] and
+// [ParseFormat], then call [RenderTreeTableWithConfig] with plan.GetPlanNodes().
+// The repository's examples/wasm/render example shows a small syscall/js wrapper
+// with that flow.
 package reference
 
 import (


### PR DESCRIPTION
Add official browser/WASM guidance now that the serialization-friendly render config API is available.

- document plantree/reference as the recommended high-level browser renderer entrypoint
- point Go callers to RenderTreeTableWithOptions and serialized callers to RenderTreeTableWithConfig
- add a small js/wasm syscall/js example that decodes QueryPlan JSON and returns explicit {output}/{error} results

Closes #29