### PR TITLE
docs: clarify IsVisible semantics

### DIFF
--- a/queryplan.go
+++ b/queryplan.go
@@ -92,6 +92,9 @@ func (qp *QueryPlan) GetNodeByIndex(id int32) *sppb.PlanNode {
 	return qp.planNodes[id]
 }
 
+// IsVisible reports whether a child link should be rendered as part of the
+// operator tree. Scalar PlanNodes are hidden unless the child link type is
+// "Scalar", which represents scalar subquery-like operator subtrees.
 func (qp *QueryPlan) IsVisible(link *sppb.PlanNode_ChildLink) bool {
 	return qp.GetNodeByChildLink(link).GetKind() == sppb.PlanNode_RELATIONAL || link.GetType() == "Scalar"
 }

--- a/queryplan.go
+++ b/queryplan.go
@@ -95,6 +95,7 @@ func (qp *QueryPlan) GetNodeByIndex(id int32) *sppb.PlanNode {
 // IsVisible reports whether a child link should be rendered as part of the
 // operator tree. Scalar PlanNodes are hidden unless the child link type is
 // "Scalar", which represents scalar subquery-like operator subtrees.
+// A nil link represents the root node.
 func (qp *QueryPlan) IsVisible(link *sppb.PlanNode_ChildLink) bool {
 	return qp.GetNodeByChildLink(link).GetKind() == sppb.PlanNode_RELATIONAL || link.GetType() == "Scalar"
 }


### PR DESCRIPTION
## Summary

- Document that `QueryPlan.IsVisible` controls operator-tree child-link visibility, not raw PlanNode existence.
- Clarify that scalar PlanNodes are hidden unless the child link type is `Scalar`.

Closes #33.

## Validation

- `go test ./...`
- `git diff --check`
- OpenCode pre-PR review on the attached diff:
  - `opencode-go/kimi-k2.6 --variant none`: no material issues, but still used reasoning tokens.
  - `opencode-go/minimax-m2.7`: reported a nil-deref concern in existing code; treated as a false positive for this docs-only diff.
  - `opencode-go/qwen3.6-plus`: no material issues.
  - custom `opencode-go/kimi-k2.6` variant with `thinking: {type: disabled}` was recognized by `opencode models --verbose`, but still emitted reasoning tokens in practice.