### PR TITLE
feat: treat Search Predicate links as predicates

### DIFF
--- a/plantree/plantree_test.go
+++ b/plantree/plantree_test.go
@@ -260,6 +260,98 @@ func TestProcessPlan_InvisibleRootReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestProcessPlan_FullTextSearchPredicates(t *testing.T) {
+	tests := []struct {
+		name      string
+		planNodes []*sppb.PlanNode
+		want      []string
+	}{
+		{
+			name: "simple search predicate",
+			planNodes: []*sppb.PlanNode{
+				{
+					Index:       0,
+					DisplayName: "Scan",
+					Kind:        sppb.PlanNode_RELATIONAL,
+					ChildLinks: []*sppb.PlanNode_ChildLink{
+						{ChildIndex: 1, Type: "Search Predicate"},
+					},
+				},
+				{
+					Index:       1,
+					DisplayName: "Search Predicate",
+					Kind:        sppb.PlanNode_SCALAR,
+					ShortRepresentation: &sppb.PlanNode_ShortRepresentation{
+						Description: "SEARCH(Tokens, 'blue')",
+					},
+				},
+			},
+			want: []string{"Search Predicate: SEARCH(Tokens, 'blue')"},
+		},
+		{
+			name: "compound search predicate function",
+			planNodes: []*sppb.PlanNode{
+				{
+					Index:       0,
+					DisplayName: "Scan",
+					Kind:        sppb.PlanNode_RELATIONAL,
+					ChildLinks: []*sppb.PlanNode_ChildLink{
+						{ChildIndex: 1, Type: "Search Predicate"},
+					},
+				},
+				{
+					Index:       1,
+					DisplayName: "Function",
+					Kind:        sppb.PlanNode_SCALAR,
+					ChildLinks: []*sppb.PlanNode_ChildLink{
+						{ChildIndex: 2, Type: "Search Predicate"},
+						{ChildIndex: 3, Type: "Search Predicate"},
+					},
+					ShortRepresentation: &sppb.PlanNode_ShortRepresentation{
+						Description: "(SEARCH(Tokens, 'blue') AND SEARCH(Tokens, 'green'))",
+					},
+				},
+				{
+					Index:       2,
+					DisplayName: "Search Predicate",
+					Kind:        sppb.PlanNode_SCALAR,
+					ShortRepresentation: &sppb.PlanNode_ShortRepresentation{
+						Description: "SEARCH(Tokens, 'blue')",
+					},
+				},
+				{
+					Index:       3,
+					DisplayName: "Search Predicate",
+					Kind:        sppb.PlanNode_SCALAR,
+					ShortRepresentation: &sppb.PlanNode_ShortRepresentation{
+						Description: "SEARCH(Tokens, 'green')",
+					},
+				},
+			},
+			want: []string{"Search Predicate: (SEARCH(Tokens, 'blue') AND SEARCH(Tokens, 'green'))"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qp, err := spannerplan.New(tt.planNodes)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			rows, err := ProcessPlan(qp)
+			if err != nil {
+				t.Fatalf("ProcessPlan() error = %v", err)
+			}
+
+			got := rowByID(t, rows, 0)
+			if diff := cmp.Diff(tt.want, got.Predicates); diff != "" {
+				t.Fatalf("Predicates mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func hangingIndentPlan(t *testing.T) *spannerplan.QueryPlan {
 	t.Helper()
 

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -387,6 +387,41 @@ func TestRenderTreeTable_InputValidation(t *testing.T) {
 	}
 }
 
+func TestRenderTreeTable_FullTextSearchPredicate(t *testing.T) {
+	planNodes := []*sppb.PlanNode{
+		{
+			Index:       0,
+			DisplayName: "Scan",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 1, Type: "Search Predicate"},
+			},
+		},
+		{
+			Index:       1,
+			DisplayName: "Search Predicate",
+			Kind:        sppb.PlanNode_SCALAR,
+			ShortRepresentation: &sppb.PlanNode_ShortRepresentation{
+				Description: "SEARCH(Tokens, 'blue')",
+			},
+		},
+	}
+
+	got, err := RenderTreeTable(planNodes, RenderModePlan, FormatCurrent, 0)
+	if err != nil {
+		t.Fatalf("RenderTreeTable() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"Predicates(identified by ID):",
+		" 0: Search Predicate: SEARCH(Tokens, 'blue')",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RenderTreeTable() output does not contain %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestRenderTreeTableWithOptions_HangingIndent(t *testing.T) {
 	input := loadWrappedPlan(t)
 	stats, _, err := queryplan.ExtractQueryPlan([]byte(input))

--- a/queryplan.go
+++ b/queryplan.go
@@ -65,15 +65,18 @@ func (qp *QueryPlan) HasStats() bool {
 }
 
 func (qp *QueryPlan) IsFunction(childLink *sppb.PlanNode_ChildLink) bool {
-	// Known predicates are Condition(Filter, Hash Join) or Seek Condition(FilterScan) or Residual Condition(FilterScan, Hash Join) or Split Range(Distributed Union).
-	// Agg(Aggregate) is a Function but not a predicate.
 	child := qp.GetNodeByChildLink(childLink)
 	return child.DisplayName == "Function"
 }
 
 func (qp *QueryPlan) IsPredicate(childLink *sppb.PlanNode_ChildLink) bool {
-	// Known predicates are Condition(Filter, Hash Join) or Seek Condition(FilterScan) or Residual Condition(FilterScan, Hash Join) or Split Range(Distributed Union).
+	// Known predicates are Search Predicate(Full Text Search), Condition(Filter, Hash Join), Seek Condition(FilterScan),
+	// Residual Condition(FilterScan, Hash Join), or Split Range(Distributed Union).
 	// Agg(Aggregate) is a Function but not a predicate.
+	if childLink.GetType() == "Search Predicate" {
+		return qp.GetNodeByChildLink(childLink).GetKind() == sppb.PlanNode_SCALAR
+	}
+
 	if !qp.IsFunction(childLink) {
 		return false
 	}

--- a/queryplan_test.go
+++ b/queryplan_test.go
@@ -116,3 +116,83 @@ func TestHasStats(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPredicate(t *testing.T) {
+	tests := []struct {
+		name      string
+		childLink *sppb.PlanNode_ChildLink
+		child     *sppb.PlanNode
+		want      bool
+	}{
+		{
+			name:      "search predicate node",
+			childLink: &sppb.PlanNode_ChildLink{ChildIndex: 1, Type: "Search Predicate"},
+			child: &sppb.PlanNode{
+				Index:       1,
+				Kind:        sppb.PlanNode_SCALAR,
+				DisplayName: "Search Predicate",
+			},
+			want: true,
+		},
+		{
+			name:      "compound search predicate function",
+			childLink: &sppb.PlanNode_ChildLink{ChildIndex: 1, Type: "Search Predicate"},
+			child: &sppb.PlanNode{
+				Index:       1,
+				Kind:        sppb.PlanNode_SCALAR,
+				DisplayName: "Function",
+			},
+			want: true,
+		},
+		{
+			name:      "search predicate link to relational node",
+			childLink: &sppb.PlanNode_ChildLink{ChildIndex: 1, Type: "Search Predicate"},
+			child: &sppb.PlanNode{
+				Index:       1,
+				Kind:        sppb.PlanNode_RELATIONAL,
+				DisplayName: "Scan",
+			},
+			want: false,
+		},
+		{
+			name:      "condition function remains predicate",
+			childLink: &sppb.PlanNode_ChildLink{ChildIndex: 1, Type: "Seek Condition"},
+			child: &sppb.PlanNode{
+				Index:       1,
+				Kind:        sppb.PlanNode_SCALAR,
+				DisplayName: "Function",
+			},
+			want: true,
+		},
+		{
+			name:      "aggregate function remains non predicate",
+			childLink: &sppb.PlanNode_ChildLink{ChildIndex: 1, Type: "Agg"},
+			child: &sppb.PlanNode{
+				Index:       1,
+				Kind:        sppb.PlanNode_SCALAR,
+				DisplayName: "Function",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qp, err := New([]*sppb.PlanNode{
+				{
+					Index:      0,
+					Kind:       sppb.PlanNode_RELATIONAL,
+					ChildLinks: []*sppb.PlanNode_ChildLink{tt.childLink},
+				},
+				tt.child,
+			})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			if got := qp.IsPredicate(tt.childLink); got != tt.want {
+				t.Fatalf("IsPredicate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #34

Summary:
- Treat scalar `Search Predicate` child links as predicates in `QueryPlan.IsPredicate`.
- Preserve existing Function/Condition/Split Range predicate behavior.
- Cover simple and compound Full Text Search predicate shapes in QueryPlan and plantree tests.
- Verify reference table rendering includes Search Predicate descriptions.

Validation:
- `go test -v ./...`
- `git diff --check`
- OpenCode diff review with `opencode-go/qwen3.6-plus`: no material issues

Note:
- `golangci-lint run --timeout=5m` could not be used locally: golangci-lint 2.12.1 reports no Go files to analyze in this checkout, and 2.6.2 panics on Go 1.26 input.