### PR TITLE
feat: expose all parent links

### DIFF
--- a/queryplan.go
+++ b/queryplan.go
@@ -12,8 +12,9 @@ import (
 )
 
 type QueryPlan struct {
-	planNodes []*sppb.PlanNode
-	parentMap map[int32]int32
+	planNodes      []*sppb.PlanNode
+	parentMap      map[int32]int32
+	parentLinksMap map[int32][]ResolvedParentLink
 }
 
 var ErrEmptyPlanNodes = errors.New("spannerplan: planNodes cannot be empty")
@@ -44,6 +45,7 @@ func New(planNodes []*sppb.PlanNode) (*QueryPlan, error) {
 	}
 
 	parentMap := make(map[int32]int32)
+	parentLinksMap := make(map[int32][]ResolvedParentLink)
 	for _, planNode := range planNodes {
 		for j, childLink := range planNode.GetChildLinks() {
 			if childLink == nil {
@@ -54,10 +56,18 @@ func New(planNodes []*sppb.PlanNode) (*QueryPlan, error) {
 				return nil, fmt.Errorf("%w: parent node %d childLinks[%d] has childIndex %d, len(planNodes)=%d", ErrChildLinkIndexOutOfRange, planNode.GetIndex(), j, childIndex, len(planNodes))
 			}
 			parentMap[childIndex] = planNode.GetIndex()
+			parentLinksMap[childIndex] = append(parentLinksMap[childIndex], ResolvedParentLink{
+				Parent:    planNode,
+				ChildLink: childLink,
+			})
 		}
 	}
 
-	return &QueryPlan{planNodes, parentMap}, nil
+	return &QueryPlan{
+		planNodes:      planNodes,
+		parentMap:      parentMap,
+		parentLinksMap: parentLinksMap,
+	}, nil
 }
 
 func (qp *QueryPlan) HasStats() bool {
@@ -126,6 +136,21 @@ func (qp *QueryPlan) GetParentNodeByChildIndex(index int32) *sppb.PlanNode {
 
 func (qp *QueryPlan) GetParentNodeByChildLink(link *sppb.PlanNode_ChildLink) *sppb.PlanNode {
 	return qp.GetParentNodeByChildIndex(link.GetChildIndex())
+}
+
+// ParentLinks returns all parent child links that point to childIndex.
+//
+// Links are returned in plan node traversal order, preserving each parent's
+// ChildLinks order. The returned slice is a copy and can be modified by callers.
+func (qp *QueryPlan) ParentLinks(childIndex int32) []ResolvedParentLink {
+	return slices.Clone(qp.parentLinksMap[childIndex])
+}
+
+// ResolvedParentLink contains a parent PlanNode and the child link that points
+// from that parent to a child node.
+type ResolvedParentLink struct {
+	Parent    *sppb.PlanNode
+	ChildLink *sppb.PlanNode_ChildLink
 }
 
 type option struct {

--- a/queryplan_test.go
+++ b/queryplan_test.go
@@ -117,6 +117,66 @@ func TestHasStats(t *testing.T) {
 	}
 }
 
+func TestParentLinks(t *testing.T) {
+	firstLink := &sppb.PlanNode_ChildLink{ChildIndex: 2, Type: "Input"}
+	secondLink := &sppb.PlanNode_ChildLink{ChildIndex: 2, Type: "Scalar"}
+	thirdLink := &sppb.PlanNode_ChildLink{ChildIndex: 2, Type: "Condition"}
+
+	qp, err := New([]*sppb.PlanNode{
+		{
+			Index:      0,
+			ChildLinks: []*sppb.PlanNode_ChildLink{firstLink, secondLink},
+		},
+		{
+			Index:      1,
+			ChildLinks: []*sppb.PlanNode_ChildLink{thirdLink},
+		},
+		{Index: 2},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	got := qp.ParentLinks(2)
+	if len(got) != 3 {
+		t.Fatalf("len(ParentLinks(2)) = %d, want 3", len(got))
+	}
+
+	want := []struct {
+		parentIndex int32
+		childLink   *sppb.PlanNode_ChildLink
+	}{
+		{parentIndex: 0, childLink: firstLink},
+		{parentIndex: 0, childLink: secondLink},
+		{parentIndex: 1, childLink: thirdLink},
+	}
+	for i, wantLink := range want {
+		if got[i].Parent.GetIndex() != wantLink.parentIndex {
+			t.Fatalf("ParentLinks(2)[%d].Parent.Index = %d, want %d", i, got[i].Parent.GetIndex(), wantLink.parentIndex)
+		}
+		if got[i].ChildLink != wantLink.childLink {
+			t.Fatalf("ParentLinks(2)[%d].ChildLink = %p, want %p", i, got[i].ChildLink, wantLink.childLink)
+		}
+	}
+
+	if got := qp.GetParentNodeByChildIndex(2).GetIndex(); got != 1 {
+		t.Fatalf("GetParentNodeByChildIndex(2) = %d, want 1", got)
+	}
+
+	got[0] = ResolvedParentLink{}
+	if got := qp.ParentLinks(2)[0]; got == (ResolvedParentLink{}) {
+		t.Fatal("ParentLinks(2) returned internal slice")
+	}
+
+	if got := qp.ParentLinks(0); got != nil {
+		t.Fatalf("ParentLinks(0) = %v, want nil", got)
+	}
+
+	if got := qp.ParentLinks(99); got != nil {
+		t.Fatalf("ParentLinks(99) = %v, want nil", got)
+	}
+}
+
 func TestIsPredicate(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Closes #35

Summary:
- Add `ResolvedParentLink` and `QueryPlan.ParentLinks(childIndex)` to expose every incoming child link for a node.
- Preserve existing `GetParentNodeByChildIndex` behavior by keeping the single-parent map unchanged.
- Preserve stable plan traversal order and return a copied slice to callers.
- Add tests for duplicate incoming links from one parent, links from multiple parents, empty/out-of-range lookups, and single-parent compatibility.

Validation:
- `go test -v ./...`
- `git diff --check`
- OpenCode diff review with `opencode-go/qwen3.6-plus`: no material issues; minor doc/edge-test suggestions addressed

Note:
- `golangci-lint run --timeout=5m` could not be used locally: golangci-lint 2.12.1 reports no Go files to analyze in this checkout.