### PR TITLE
feat: add scalar appendix sections

### DIFF
--- a/asciitable/asciitable.go
+++ b/asciitable/asciitable.go
@@ -47,7 +47,30 @@ type TableSpec[T any] struct {
 	Columns []Column[T]
 }
 
+// AppendixSpec defines how appendices read row IDs and item lines.
+type AppendixSpec[T any] struct {
+	// Title is printed before item lines.
+	Title string
+	// ID returns the non-negative display ID used in the appendix.
+	ID func(row T) uint
+	// Items returns the item lines associated with the row.
+	Items func(row T) []string
+}
+
+type appendixRows struct {
+	rows        []appendixRow
+	hasItems    bool
+	maxIDLength int
+}
+
+type appendixRow struct {
+	id    uint
+	items []string
+}
+
 // PredicateSpec defines how predicate appendices read row IDs and predicate lines.
+//
+// Deprecated: use [AppendixSpec] with [RenderAppendix].
 type PredicateSpec[T any] struct {
 	// Title is printed before predicate lines. The zero value uses
 	// "Predicates(identified by ID):".
@@ -56,17 +79,6 @@ type PredicateSpec[T any] struct {
 	ID func(row T) uint
 	// Predicates returns the predicate lines associated with the row.
 	Predicates func(row T) []string
-}
-
-type predicateRows struct {
-	rows          []predicateRow
-	hasPredicates bool
-	maxIDLength   int
-}
-
-type predicateRow struct {
-	id         uint
-	predicates []string
 }
 
 // RenderTable renders rows using spec.
@@ -119,56 +131,70 @@ func RenderTable[T any](rows []T, spec TableSpec[T]) (string, error) {
 	return sb.String(), nil
 }
 
-// RenderPredicates formats the predicate appendix for rows with predicates.
-func RenderPredicates[T any](rows []T, spec PredicateSpec[T]) (string, error) {
-	resolved, err := collectPredicateRows(rows, spec)
+// RenderAppendix formats an appendix for rows with associated items.
+func RenderAppendix[T any](rows []T, spec AppendixSpec[T]) (string, error) {
+	resolved, err := collectAppendixRows(rows, spec)
 	if err != nil {
 		return "", err
 	}
-	if !resolved.hasPredicates {
+	if !resolved.hasItems {
 		return "", nil
 	}
 
 	var sb strings.Builder
-	title := spec.Title
-	if title == "" {
-		title = "Predicates(identified by ID):"
-	}
-	_, _ = fmt.Fprintln(&sb, title)
+	_, _ = fmt.Fprintln(&sb, spec.Title)
 	for _, row := range resolved.rows {
-		for i, predicate := range row.predicates {
+		for i, item := range row.items {
 			idPartStr := ""
 			if i == 0 {
 				idPartStr = strconv.FormatUint(uint64(row.id), 10) + ":"
 			}
 
 			prefix := tabwrap.FillLeft(idPartStr, resolved.maxIDLength+1)
-			_, _ = fmt.Fprintf(&sb, " %s %s\n", prefix, predicate)
+			_, _ = fmt.Fprintf(&sb, " %s %s\n", prefix, item)
 		}
 	}
 	return sb.String(), nil
 }
 
-func collectPredicateRows[T any](rows []T, spec PredicateSpec[T]) (predicateRows, error) {
-	if spec.ID == nil {
-		return predicateRows{}, fmt.Errorf("predicate spec has nil ID")
+// RenderPredicates formats the predicate appendix for rows with predicates.
+//
+// Deprecated: use [RenderAppendix].
+func RenderPredicates[T any](rows []T, spec PredicateSpec[T]) (string, error) {
+	title := spec.Title
+	if title == "" {
+		title = "Predicates(identified by ID):"
 	}
-	if spec.Predicates == nil {
-		return predicateRows{}, fmt.Errorf("predicate spec has nil Predicates")
+	return RenderAppendix(rows, AppendixSpec[T]{
+		Title: title,
+		ID:    spec.ID,
+		Items: spec.Predicates,
+	})
+}
+
+func collectAppendixRows[T any](rows []T, spec AppendixSpec[T]) (appendixRows, error) {
+	if spec.Title == "" {
+		return appendixRows{}, fmt.Errorf("appendix spec has empty Title")
+	}
+	if spec.ID == nil {
+		return appendixRows{}, fmt.Errorf("appendix spec has nil ID")
+	}
+	if spec.Items == nil {
+		return appendixRows{}, fmt.Errorf("appendix spec has nil Items")
 	}
 
-	var resolved predicateRows
+	var resolved appendixRows
 	for _, row := range rows {
 		id := spec.ID(row)
-		predicates := spec.Predicates(row)
+		items := spec.Items(row)
 		if idLength := len(strconv.FormatUint(uint64(id), 10)); idLength > resolved.maxIDLength {
 			resolved.maxIDLength = idLength
 		}
-		if len(predicates) > 0 {
-			resolved.hasPredicates = true
-			resolved.rows = append(resolved.rows, predicateRow{
-				id:         id,
-				predicates: predicates,
+		if len(items) > 0 {
+			resolved.hasItems = true
+			resolved.rows = append(resolved.rows, appendixRow{
+				id:    id,
+				items: items,
 			})
 		}
 	}

--- a/asciitable/asciitable.go
+++ b/asciitable/asciitable.go
@@ -55,6 +55,8 @@ type AppendixSpec[T any] struct {
 	ID func(row T) uint
 	// Items returns the item lines associated with the row.
 	Items func(row T) []string
+	// WrapWidth is the maximum full line width, including the ID prefix. A value of 0 disables wrapping.
+	WrapWidth int
 }
 
 type appendixRows struct {
@@ -131,7 +133,11 @@ func RenderAppendix[T any](rows []T, spec AppendixSpec[T]) (string, error) {
 	var sb strings.Builder
 	_, _ = fmt.Fprintln(&sb, spec.Title)
 	for _, row := range resolved.rows {
-		for i, item := range row.items {
+		items := row.items
+		if spec.WrapWidth > 0 {
+			items = wrapAppendixItems(items, spec.WrapWidth-(resolved.maxIDLength+3))
+		}
+		for i, item := range items {
 			idPartStr := ""
 			if i == 0 {
 				idPartStr = strconv.FormatUint(uint64(row.id), 10) + ":"
@@ -142,6 +148,39 @@ func RenderAppendix[T any](rows []T, spec AppendixSpec[T]) (string, error) {
 		}
 	}
 	return sb.String(), nil
+}
+
+func wrapAppendixItems(items []string, width int) []string {
+	if width <= 0 {
+		return items
+	}
+
+	var wrapped []string
+	for _, item := range items {
+		for _, line := range strings.Split(item, "\n") {
+			wrapped = append(wrapped, wrapAppendixLine(line, width)...)
+		}
+	}
+	return wrapped
+}
+
+func wrapAppendixLine(line string, width int) []string {
+	if width <= 0 || len(line) <= width {
+		return []string{line}
+	}
+
+	var wrapped []string
+	rest := line
+	for len(rest) > width {
+		cut := width
+		if space := strings.LastIndexAny(rest[:min(len(rest), width+1)], " \t"); space > 0 {
+			cut = space
+		}
+		wrapped = append(wrapped, strings.TrimRight(rest[:cut], " \t"))
+		rest = strings.TrimLeft(rest[cut:], " \t")
+	}
+	wrapped = append(wrapped, rest)
+	return wrapped
 }
 
 func collectAppendixRows[T any](rows []T, spec AppendixSpec[T]) (appendixRows, error) {

--- a/asciitable/asciitable.go
+++ b/asciitable/asciitable.go
@@ -55,8 +55,6 @@ type AppendixSpec[T any] struct {
 	ID func(row T) uint
 	// Items returns the item lines associated with the row.
 	Items func(row T) []string
-	// WrapWidth is the maximum full line width, including the ID prefix. A value of 0 disables wrapping.
-	WrapWidth int
 }
 
 type appendixRows struct {
@@ -133,11 +131,7 @@ func RenderAppendix[T any](rows []T, spec AppendixSpec[T]) (string, error) {
 	var sb strings.Builder
 	_, _ = fmt.Fprintln(&sb, spec.Title)
 	for _, row := range resolved.rows {
-		items := row.items
-		if spec.WrapWidth > 0 {
-			items = wrapAppendixItems(items, spec.WrapWidth-(resolved.maxIDLength+3))
-		}
-		for i, item := range items {
+		for i, item := range row.items {
 			idPartStr := ""
 			if i == 0 {
 				idPartStr = strconv.FormatUint(uint64(row.id), 10) + ":"
@@ -148,39 +142,6 @@ func RenderAppendix[T any](rows []T, spec AppendixSpec[T]) (string, error) {
 		}
 	}
 	return sb.String(), nil
-}
-
-func wrapAppendixItems(items []string, width int) []string {
-	if width <= 0 {
-		return items
-	}
-
-	var wrapped []string
-	for _, item := range items {
-		for _, line := range strings.Split(item, "\n") {
-			wrapped = append(wrapped, wrapAppendixLine(line, width)...)
-		}
-	}
-	return wrapped
-}
-
-func wrapAppendixLine(line string, width int) []string {
-	if width <= 0 || len(line) <= width {
-		return []string{line}
-	}
-
-	var wrapped []string
-	rest := line
-	for len(rest) > width {
-		cut := width
-		if space := strings.LastIndexAny(rest[:min(len(rest), width+1)], " \t"); space > 0 {
-			cut = space
-		}
-		wrapped = append(wrapped, strings.TrimRight(rest[:cut], " \t"))
-		rest = strings.TrimLeft(rest[cut:], " \t")
-	}
-	wrapped = append(wrapped, rest)
-	return wrapped
 }
 
 func collectAppendixRows[T any](rows []T, spec AppendixSpec[T]) (appendixRows, error) {

--- a/asciitable/asciitable.go
+++ b/asciitable/asciitable.go
@@ -49,9 +49,7 @@ type TableSpec[T any] struct {
 
 // AppendixSpec defines how appendices read row IDs and item lines.
 type AppendixSpec[T any] struct {
-	// Title is printed before item lines. It must be non-empty; callers that want
-	// the predicate default title can use [PredicateSpec] or provide
-	// "Predicates(identified by ID):".
+	// Title is printed before item lines. It must be non-empty.
 	Title string
 	// ID returns the non-negative display ID used in the appendix.
 	ID func(row T) uint
@@ -68,19 +66,6 @@ type appendixRows struct {
 type appendixRow struct {
 	id    uint
 	items []string
-}
-
-// PredicateSpec defines how predicate appendices read row IDs and predicate lines.
-//
-// Deprecated: use [AppendixSpec] with [RenderAppendix].
-type PredicateSpec[T any] struct {
-	// Title is printed before predicate lines. The zero value uses
-	// "Predicates(identified by ID):".
-	Title string
-	// ID returns the non-negative display ID used in the predicate appendix.
-	ID func(row T) uint
-	// Predicates returns the predicate lines associated with the row.
-	Predicates func(row T) []string
 }
 
 // RenderTable renders rows using spec.
@@ -157,21 +142,6 @@ func RenderAppendix[T any](rows []T, spec AppendixSpec[T]) (string, error) {
 		}
 	}
 	return sb.String(), nil
-}
-
-// RenderPredicates formats the predicate appendix for rows with predicates.
-//
-// Deprecated: use [RenderAppendix].
-func RenderPredicates[T any](rows []T, spec PredicateSpec[T]) (string, error) {
-	title := spec.Title
-	if title == "" {
-		title = "Predicates(identified by ID):"
-	}
-	return RenderAppendix(rows, AppendixSpec[T]{
-		Title: title,
-		ID:    spec.ID,
-		Items: spec.Predicates,
-	})
 }
 
 func collectAppendixRows[T any](rows []T, spec AppendixSpec[T]) (appendixRows, error) {

--- a/asciitable/asciitable.go
+++ b/asciitable/asciitable.go
@@ -49,7 +49,9 @@ type TableSpec[T any] struct {
 
 // AppendixSpec defines how appendices read row IDs and item lines.
 type AppendixSpec[T any] struct {
-	// Title is printed before item lines.
+	// Title is printed before item lines. It must be non-empty; callers that want
+	// the predicate default title can use [PredicateSpec] or provide
+	// "Predicates(identified by ID):".
 	Title string
 	// ID returns the non-negative display ID used in the appendix.
 	ID func(row T) uint

--- a/asciitable/asciitable_test.go
+++ b/asciitable/asciitable_test.go
@@ -146,15 +146,15 @@ func TestRenderTable_InvalidSpec(t *testing.T) {
 	}
 }
 
-func TestRenderPredicates(t *testing.T) {
+func TestRenderAppendix(t *testing.T) {
 	rows := []testRow{
 		{id: 3, text: "Filter", predicates: []string{"Filter: a = 1", "Expression: b"}},
 		{id: 12, text: "Scan", predicates: []string{"Seek Condition: k = 1"}},
 	}
 
-	got, err := asciitable.RenderPredicates(rows, testPredicateSpec())
+	got, err := asciitable.RenderAppendix(rows, testAppendixSpec("Predicates(identified by ID):"))
 	if err != nil {
-		t.Fatalf("RenderPredicates() error = %v", err)
+		t.Fatalf("RenderAppendix() error = %v", err)
 	}
 	want := heredoc.Doc(`
 		Predicates(identified by ID):
@@ -163,39 +163,37 @@ func TestRenderPredicates(t *testing.T) {
 		 12: Seek Condition: k = 1
 	`)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("RenderPredicates() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("RenderAppendix() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestRenderPredicates_CustomTitle(t *testing.T) {
+func TestRenderAppendix_CustomTitle(t *testing.T) {
 	rows := []testRow{
 		{id: 3, text: "Filter", predicates: []string{"Filter: a = 1"}},
 	}
-	spec := testPredicateSpec()
-	spec.Title = "Filters:"
 
-	got, err := asciitable.RenderPredicates(rows, spec)
+	got, err := asciitable.RenderAppendix(rows, testAppendixSpec("Filters:"))
 	if err != nil {
-		t.Fatalf("RenderPredicates() error = %v", err)
+		t.Fatalf("RenderAppendix() error = %v", err)
 	}
 	want := heredoc.Doc(`
 		Filters:
 		 3: Filter: a = 1
 	`)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("RenderPredicates() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("RenderAppendix() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestRenderPredicates_MultiDigitIDs(t *testing.T) {
+func TestRenderAppendix_MultiDigitIDs(t *testing.T) {
 	rows := []testRow{
 		{id: 3, text: "Filter", predicates: []string{"Filter: a = 1", "Expression: b"}},
 		{id: 120, text: "Scan", predicates: []string{"Seek Condition: k = 1"}},
 	}
 
-	got, err := asciitable.RenderPredicates(rows, testPredicateSpec())
+	got, err := asciitable.RenderAppendix(rows, testAppendixSpec("Predicates(identified by ID):"))
 	if err != nil {
-		t.Fatalf("RenderPredicates() error = %v", err)
+		t.Fatalf("RenderAppendix() error = %v", err)
 	}
 	want := heredoc.Doc(`
 		Predicates(identified by ID):
@@ -204,41 +202,42 @@ func TestRenderPredicates_MultiDigitIDs(t *testing.T) {
 		 120: Seek Condition: k = 1
 	`)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("RenderPredicates() mismatch (-want +got):\n%s", diff)
+		t.Fatalf("RenderAppendix() mismatch (-want +got):\n%s", diff)
 	}
 }
 
-func TestRenderPredicates_None(t *testing.T) {
-	got, err := asciitable.RenderPredicates([]testRow{{id: 1, text: "Root"}}, testPredicateSpec())
+func TestRenderAppendix_None(t *testing.T) {
+	got, err := asciitable.RenderAppendix([]testRow{{id: 1, text: "Root"}}, testAppendixSpec("Predicates(identified by ID):"))
 	if err != nil {
-		t.Fatalf("RenderPredicates() error = %v", err)
+		t.Fatalf("RenderAppendix() error = %v", err)
 	}
 	if got != "" {
-		t.Fatalf("RenderPredicates() = %q, want empty", got)
+		t.Fatalf("RenderAppendix() = %q, want empty", got)
 	}
 }
 
-func TestRenderPredicates_ReadsEachRowOnce(t *testing.T) {
+func TestRenderAppendix_ReadsEachRowOnce(t *testing.T) {
 	rows := []testRow{
 		{id: 1, text: "Root"},
 		{id: 2, text: "Filter", predicates: []string{"Filter: true"}},
 	}
 	var idCalls int
 	var predicateCalls int
-	spec := asciitable.PredicateSpec[testRow]{
+	spec := asciitable.AppendixSpec[testRow]{
+		Title: "Predicates(identified by ID):",
 		ID: func(row testRow) uint {
 			idCalls++
 			return row.id
 		},
-		Predicates: func(row testRow) []string {
+		Items: func(row testRow) []string {
 			predicateCalls++
 			return row.predicates
 		},
 	}
 
-	_, err := asciitable.RenderPredicates(rows, spec)
+	_, err := asciitable.RenderAppendix(rows, spec)
 	if err != nil {
-		t.Fatalf("RenderPredicates() error = %v", err)
+		t.Fatalf("RenderAppendix() error = %v", err)
 	}
 	if idCalls != len(rows) {
 		t.Fatalf("ID calls = %d, want %d", idCalls, len(rows))
@@ -248,14 +247,32 @@ func TestRenderPredicates_ReadsEachRowOnce(t *testing.T) {
 	}
 }
 
-func TestRenderPredicates_InvalidSpec(t *testing.T) {
+func TestRenderAppendix_InvalidSpec(t *testing.T) {
 	rows := []testRow{
 		{id: 1, text: "Root", predicates: []string{"Filter: true"}},
 	}
 
-	_, err := asciitable.RenderPredicates(rows, asciitable.PredicateSpec[testRow]{})
+	_, err := asciitable.RenderAppendix(rows, asciitable.AppendixSpec[testRow]{})
 	if err == nil {
-		t.Fatal("RenderPredicates() error = nil, want non-nil")
+		t.Fatal("RenderAppendix() error = nil, want non-nil")
+	}
+}
+
+func TestRenderPredicates_DefaultTitle(t *testing.T) {
+	rows := []testRow{
+		{id: 3, text: "Filter", predicates: []string{"Filter: a = 1"}},
+	}
+
+	got, err := asciitable.RenderPredicates(rows, testPredicateSpec())
+	if err != nil {
+		t.Fatalf("RenderPredicates() error = %v", err)
+	}
+	want := heredoc.Doc(`
+		Predicates(identified by ID):
+		 3: Filter: a = 1
+	`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("RenderPredicates() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -285,6 +302,18 @@ func testPredicateSpec() asciitable.PredicateSpec[testRow] {
 			return row.id
 		},
 		Predicates: func(row testRow) []string {
+			return row.predicates
+		},
+	}
+}
+
+func testAppendixSpec(title string) asciitable.AppendixSpec[testRow] {
+	return asciitable.AppendixSpec[testRow]{
+		Title: title,
+		ID: func(row testRow) uint {
+			return row.id
+		},
+		Items: func(row testRow) []string {
 			return row.predicates
 		},
 	}

--- a/asciitable/asciitable_test.go
+++ b/asciitable/asciitable_test.go
@@ -222,7 +222,7 @@ func TestRenderAppendix_ReadsEachRowOnce(t *testing.T) {
 		{id: 2, text: "Filter", predicates: []string{"Filter: true"}},
 	}
 	var idCalls int
-	var predicateCalls int
+	var itemsCalls int
 	spec := asciitable.AppendixSpec[testRow]{
 		Title: "Predicates(identified by ID):",
 		ID: func(row testRow) uint {
@@ -230,7 +230,7 @@ func TestRenderAppendix_ReadsEachRowOnce(t *testing.T) {
 			return row.id
 		},
 		Items: func(row testRow) []string {
-			predicateCalls++
+			itemsCalls++
 			return row.predicates
 		},
 	}
@@ -242,8 +242,8 @@ func TestRenderAppendix_ReadsEachRowOnce(t *testing.T) {
 	if idCalls != len(rows) {
 		t.Fatalf("ID calls = %d, want %d", idCalls, len(rows))
 	}
-	if predicateCalls != len(rows) {
-		t.Fatalf("Predicates calls = %d, want %d", predicateCalls, len(rows))
+	if itemsCalls != len(rows) {
+		t.Fatalf("Items calls = %d, want %d", itemsCalls, len(rows))
 	}
 }
 

--- a/asciitable/asciitable_test.go
+++ b/asciitable/asciitable_test.go
@@ -206,6 +206,27 @@ func TestRenderAppendix_MultiDigitIDs(t *testing.T) {
 	}
 }
 
+func TestRenderAppendix_WrapWidth(t *testing.T) {
+	rows := []testRow{
+		{id: 3, text: "Sort", predicates: []string{"Key: alpha, beta, gamma"}},
+	}
+	spec := testAppendixSpec("Ordering(identified by ID):")
+	spec.WrapWidth = 20
+
+	got, err := asciitable.RenderAppendix(rows, spec)
+	if err != nil {
+		t.Fatalf("RenderAppendix() error = %v", err)
+	}
+	want := heredoc.Doc(`
+		Ordering(identified by ID):
+		 3: Key: alpha,
+		    beta, gamma
+	`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("RenderAppendix() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestRenderAppendix_None(t *testing.T) {
 	got, err := asciitable.RenderAppendix([]testRow{{id: 1, text: "Root"}}, testAppendixSpec("Predicates(identified by ID):"))
 	if err != nil {

--- a/asciitable/asciitable_test.go
+++ b/asciitable/asciitable_test.go
@@ -258,24 +258,6 @@ func TestRenderAppendix_InvalidSpec(t *testing.T) {
 	}
 }
 
-func TestRenderPredicates_DefaultTitle(t *testing.T) {
-	rows := []testRow{
-		{id: 3, text: "Filter", predicates: []string{"Filter: a = 1"}},
-	}
-
-	got, err := asciitable.RenderPredicates(rows, testPredicateSpec())
-	if err != nil {
-		t.Fatalf("RenderPredicates() error = %v", err)
-	}
-	want := heredoc.Doc(`
-		Predicates(identified by ID):
-		 3: Filter: a = 1
-	`)
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("RenderPredicates() mismatch (-want +got):\n%s", diff)
-	}
-}
-
 func idColumn() asciitable.Column[testRow] {
 	return asciitable.Column[testRow]{
 		Header:    "ID",
@@ -292,17 +274,6 @@ func operatorColumn() asciitable.Column[testRow] {
 		Alignment: asciitable.AlignLeft,
 		Cell: func(row testRow, _ int) string {
 			return row.text
-		},
-	}
-}
-
-func testPredicateSpec() asciitable.PredicateSpec[testRow] {
-	return asciitable.PredicateSpec[testRow]{
-		ID: func(row testRow) uint {
-			return row.id
-		},
-		Predicates: func(row testRow) []string {
-			return row.predicates
 		},
 	}
 }

--- a/asciitable/asciitable_test.go
+++ b/asciitable/asciitable_test.go
@@ -206,27 +206,6 @@ func TestRenderAppendix_MultiDigitIDs(t *testing.T) {
 	}
 }
 
-func TestRenderAppendix_WrapWidth(t *testing.T) {
-	rows := []testRow{
-		{id: 3, text: "Sort", predicates: []string{"Key: alpha, beta, gamma"}},
-	}
-	spec := testAppendixSpec("Ordering(identified by ID):")
-	spec.WrapWidth = 20
-
-	got, err := asciitable.RenderAppendix(rows, spec)
-	if err != nil {
-		t.Fatalf("RenderAppendix() error = %v", err)
-	}
-	want := heredoc.Doc(`
-		Ordering(identified by ID):
-		 3: Key: alpha,
-		    beta, gamma
-	`)
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("RenderAppendix() mismatch (-want +got):\n%s", diff)
-	}
-}
-
 func TestRenderAppendix_None(t *testing.T) {
 	got, err := asciitable.RenderAppendix([]testRow{{id: 1, text: "Root"}}, testAppendixSpec("Predicates(identified by ID):"))
 	if err != nil {

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -54,6 +54,60 @@ Note: `--mode=PLAN` and `--mode=PROFILE` can be omitted because the default `--m
 Use a comma-separated list for focused sections, for example `--print=predicates,ordering`.
 `typed` and `full` are intentionally noisy debug dumps and cannot be combined with other sections.
 
+For example, the following query has a `WHERE` predicate, aggregation, and ordering:
+
+```sql
+SELECT SongGenre, COUNT(*) AS SongCount
+FROM Songs
+WHERE SongName LIKE 'A%'
+GROUP BY SongGenre
+ORDER BY SongCount DESC, SongGenre
+LIMIT 5
+```
+
+Rendering the captured PLAN JSON with `--print=predicates,ordering,aggregate` shows only the selected scalar details:
+
+```
+$ rendertree --mode=PLAN --print=predicates,ordering,aggregate < plan.json
++-----+--------------------------------------------------------------------------------------+
+| ID  | Operator                                                                             |
++-----+--------------------------------------------------------------------------------------+
+|   0 | Serialize Result <Row>                                                               |
+|   1 | +- Global Sort Limit <Row>                                                           |
+|   2 |    +- Global Hash Aggregate <Row>                                                    |
+|  *3 |       +- Distributed Union on SongsBySongName <Row>                                  |
+|   4 |          +- Local Hash Aggregate <Row>                                               |
+|  *5 |             +- Distributed Cross Apply <Row>                                         |
+|   6 |                +- [Input] Create Batch <Batch>                                       |
+|   7 |                |  +- RowToDataBlock                                                  |
+|   8 |                |     +- Local Distributed Union <Row>                                |
+|   9 |                |        +- Filter Scan <Row> (seekable_key_size: 1)                  |
+| *10 |                |           +- Index Scan on SongsBySongName <Row> (scan_method: Row) |
+|  22 |                +- [Map] Local Hash Aggregate <Row>                                   |
+|  23 |                   +- Cross Apply <Row>                                               |
+|  24 |                      +- [Input] KeyRangeAccumulator <Row>                            |
+|  25 |                      |  +- DataBlockToRow                                            |
+|  26 |                      |     +- Batch Scan on $v5 <Batch> (scan_method: Batch)         |
+|  33 |                      +- [Map] Local Distributed Union <Row>                          |
+|  34 |                         +- Filter Scan <Row> (seekable_key_size: 0)                  |
+| *35 |                            +- Table Scan on Songs <Row> (scan_method: Row)           |
++-----+--------------------------------------------------------------------------------------+
+Predicates(identified by ID):
+  3: Split Range: STARTS_WITH($SongName, 'A')
+  5: Split Range: (($Songs_key_SingerId'3 = $Songs_key_SingerId'2) AND ($Songs_key_AlbumId'3 = $Songs_key_AlbumId'2) AND ($Songs_key_TrackId'3 = $Songs_key_TrackId'2))
+ 10: Seek Condition: STARTS_WITH($SongName, 'A')
+ 35: Seek Condition: (($Songs_key_SingerId'3 = $batched_Songs_key_SingerId'3) AND ($Songs_key_AlbumId'3 = $batched_Songs_key_AlbumId'3) AND ($Songs_key_TrackId'3 = $batched_Songs_key_TrackId'3))
+Ordering(identified by ID):
+  1: Key: $sort_SongCount=$SongCount (DESC), $sort_group_SongGenre'2=$group_SongGenre'2
+Aggregates(identified by ID):
+  2: Key: $group_SongGenre'2=$group_SongGenre'
+     Agg: $SongCount=COUNT_FINAL($v1)
+  4: Key: $group_SongGenre'=$group_SongGenre
+     Agg: $v1=COUNT_FINAL($v3)
+ 22: Key: $group_SongGenre=$SongGenre
+     Agg: $v3=COUNT()
+```
+
 Rendered stats columns are customizable using `--custom-file` or repeatable `--custom-column` flags. `--custom-file`, `--custom-column`, and deprecated `--custom` are mutually exclusive.
 
 ```

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -54,6 +54,12 @@ Note: `--mode=PLAN` and `--mode=PROFILE` can be omitted because the default `--m
 Use a comma-separated list for focused sections, for example `--print=predicates,ordering`.
 `typed` and `full` are intentionally noisy debug dumps and cannot be combined with other sections.
 
+Semantic appendix sections hide scalar assignment variable names by default. Use `--show-vars` when
+the assignment name itself is useful, for example to inspect what `$v1` is assigned to. Use
+`--resolve-vars` to replace direct scalar variable aliases with their assigned expression in semantic
+appendix sections. `--resolve-vars-recursive` is experimental and recursively traces aliases; it is
+useful for investigation, but can produce noisier expanded expressions.
+
 For example, the following query has a `WHERE` predicate, aggregation, and ordering:
 
 ```sql

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -98,14 +98,14 @@ Predicates(identified by ID):
  10: Seek Condition: STARTS_WITH($SongName, 'A')
  35: Seek Condition: (($Songs_key_SingerId'3 = $batched_Songs_key_SingerId'3) AND ($Songs_key_AlbumId'3 = $batched_Songs_key_AlbumId'3) AND ($Songs_key_TrackId'3 = $batched_Songs_key_TrackId'3))
 Ordering(identified by ID):
-  1: Key: $sort_SongCount=$SongCount (DESC), $sort_group_SongGenre'2=$group_SongGenre'2
+  1: Key: $SongCount (DESC), $group_SongGenre'2
 Aggregates(identified by ID):
-  2: Key: $group_SongGenre'2=$group_SongGenre'
-     Agg: $SongCount=COUNT_FINAL($v1)
-  4: Key: $group_SongGenre'=$group_SongGenre
-     Agg: $v1=COUNT_FINAL($v3)
- 22: Key: $group_SongGenre=$SongGenre
-     Agg: $v3=COUNT()
+  2: Key: $group_SongGenre'
+     Agg: COUNT_FINAL($v1)
+  4: Key: $group_SongGenre
+     Agg: COUNT_FINAL($v3)
+ 22: Key: $SongGenre
+     Agg: COUNT()
 ```
 
 Rendered stats columns are customizable using `--custom-file` or repeatable `--custom-column` flags. `--custom-file`, `--custom-column`, and deprecated `--custom` are mutually exclusive.

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -43,6 +43,17 @@ $ gcloud spanner databases execute-sql ${DATABASE_ID} --sql="SELECT * FROM Singe
 
 Note: `--mode=PLAN` and `--mode=PROFILE` can be omitted because the default `--mode=AUTO` can detect whether the input has execution statistics or not.
 
+`rendertree` prints predicate-like scalar parameters by default. The `--print` flag can select one or more appendix sections:
+
+- `predicates` prints predicate-like scalar links such as `Condition`, `Residual Condition`, `Seek Condition`, `Search Predicate`, and `Split Range`.
+- `ordering` prints ordering details from `Sort`, `Sort Limit`, `Minor Sort`, and `Minor Sort Limit` operators.
+- `aggregate` prints `Key` and `Agg` details from `Aggregate` operators.
+- `typed` prints all typed scalar links as a raw debug dump.
+- `full` prints all scalar links, including unnamed links, as a raw debug dump.
+
+Use a comma-separated list for focused sections, for example `--print=predicates,ordering`.
+`typed` and `full` are intentionally noisy debug dumps and cannot be combined with other sections.
+
 Rendered stats columns are customizable using `--custom-file` or repeatable `--custom-column` flags. `--custom-file`, `--custom-column`, and deprecated `--custom` are mutually exclusive.
 
 ```

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -107,7 +107,7 @@ Predicates(identified by ID):
  35: Seek Condition: (($Songs_key_SingerId'3 = $batched_Songs_key_SingerId'3) AND ($Songs_key_AlbumId'3 = $batched_Songs_key_AlbumId'3) AND ($Songs_key_TrackId'3 = $batched_Songs_key_TrackId'3))
 
 Ordering(identified by ID):
-  1: Key: $SongCount (DESC), $group_SongGenre'2
+  1: Key: $SongCount DESC, $group_SongGenre'2
 
 Aggregates(identified by ID):
   2: Key: $group_SongGenre'

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -59,8 +59,7 @@ Semantic appendix sections hide scalar assignment variable names by default. Use
 the assignment name itself is useful, for example to inspect what `$v1` is assigned to. Use
 `--resolve-vars` to replace direct scalar variable aliases with their assigned expression in semantic
 appendix sections. `--resolve-vars-recursive` is experimental and recursively traces aliases; it is
-useful for investigation, but can produce noisier expanded expressions. Use
-`--appendix-wrap-width` to wrap long appendix lines independently from Operator column wrapping.
+useful for investigation, but can produce noisier expanded expressions.
 
 For example, the following query has a `WHERE` predicate, aggregation, and ordering:
 
@@ -264,8 +263,6 @@ rendertree supports a compact format and wrapping for limited width environment.
   - Whitespaces are not inserted for operator and metadata display unless it causes ambiguity.
 - `--wrap-width` specifies the number of characters at which to wrap the content of the Operator column.
   - The tree won't be broken even when operator lines are wrapped.
-- `--appendix-wrap-width` specifies the number of characters at which to wrap appendix lines.
-  - This is independent from `--wrap-width` because appendix lines do not include the tree/table layout.
 - `--hanging-indent` enables hanging indent for wrapped lines.
   - Wrapped continuation lines align after node-local prefixes such as `[Input] ` and `[Map] `.
   - Without this flag, wrapped lines keep the original tree-aligned indentation.

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -24,6 +24,7 @@ $ cat queryplan.yaml | rendertree --mode=PLAN
 | *3 |       +- FilterScan                     |
 |  4 |          +- Table Scan (Table: Singers) |
 +----+-----------------------------------------+
+
 Predicates(identified by ID):
  0: Split Range: ($SingerId = 1)
  3: Seek Condition: ($SingerId = 1)
@@ -58,7 +59,8 @@ Semantic appendix sections hide scalar assignment variable names by default. Use
 the assignment name itself is useful, for example to inspect what `$v1` is assigned to. Use
 `--resolve-vars` to replace direct scalar variable aliases with their assigned expression in semantic
 appendix sections. `--resolve-vars-recursive` is experimental and recursively traces aliases; it is
-useful for investigation, but can produce noisier expanded expressions.
+useful for investigation, but can produce noisier expanded expressions. Use
+`--appendix-wrap-width` to wrap long appendix lines independently from Operator column wrapping.
 
 For example, the following query has a `WHERE` predicate, aggregation, and ordering:
 
@@ -98,13 +100,16 @@ $ rendertree --mode=PLAN --print=predicates,ordering,aggregate < plan.json
 |  34 |                         +- Filter Scan <Row> (seekable_key_size: 0)                  |
 | *35 |                            +- Table Scan on Songs <Row> (scan_method: Row)           |
 +-----+--------------------------------------------------------------------------------------+
+
 Predicates(identified by ID):
   3: Split Range: STARTS_WITH($SongName, 'A')
   5: Split Range: (($Songs_key_SingerId'3 = $Songs_key_SingerId'2) AND ($Songs_key_AlbumId'3 = $Songs_key_AlbumId'2) AND ($Songs_key_TrackId'3 = $Songs_key_TrackId'2))
  10: Seek Condition: STARTS_WITH($SongName, 'A')
  35: Seek Condition: (($Songs_key_SingerId'3 = $batched_Songs_key_SingerId'3) AND ($Songs_key_AlbumId'3 = $batched_Songs_key_AlbumId'3) AND ($Songs_key_TrackId'3 = $batched_Songs_key_TrackId'3))
+
 Ordering(identified by ID):
   1: Key: $SongCount (DESC), $group_SongGenre'2
+
 Aggregates(identified by ID):
   2: Key: $group_SongGenre'
      Agg: COUNT_FINAL($v1)
@@ -179,6 +184,7 @@ $ rendertree --custom-file custom.example.yaml < profile.yaml
 |  33 |             +- Filter Scan <Row> (seekable_key_size: 0)                  |      |         |
 | *34 |                +- Table Scan on Songs <Row> (scan_method: Row)           | 3069 |    3069 |
 +-----+--------------------------------------------------------------------------+------+---------+
+
 Predicates(identified by ID):
   0: Split Range: (STARTS_WITH($SongName, 'Th') AND ($SongName LIKE 'Th%e'))
   1: Split Range: (($SingerId' = $SingerId) AND ($AlbumId' = $AlbumId) AND ($TrackId' = $TrackId))
@@ -207,6 +213,7 @@ $ rendertree --inline-stats --custom-file custom.example.yaml < profile.yaml
 |  33 |             +- Filter Scan <Row> (seekable_key_size: 0)                                 |      |
 | *34 |                +- Table Scan on Songs <Row> (scan_method: Row, scanned=3069)            | 3069 |
 +-----+-----------------------------------------------------------------------------------------+------+
+
 Predicates(identified by ID):
   0: Split Range: (STARTS_WITH($SongName, 'Th') AND ($SongName LIKE 'Th%e'))
   1: Split Range: (($SingerId' = $SingerId) AND ($AlbumId' = $AlbumId) AND ($TrackId' = $TrackId))
@@ -240,6 +247,7 @@ $ cat distributed_cross_apply_profile.yaml | \
 | *17 |             +- Filter Scan <Row> (seekable_key_size: 0)                                   |          |
 |  18 |                +- Index Scan on SongsBySongGenre <Row> (Full scan, scan_method: Row)      | 0.18 ms  |
 +-----+-------------------------------------------------------------------------------------------+----------+
+
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
@@ -255,7 +263,9 @@ rendertree supports a compact format and wrapping for limited width environment.
   - Each level of depth in the Query Plan tree adds only one character to its indentation.
   - Whitespaces are not inserted for operator and metadata display unless it causes ambiguity.
 - `--wrap-width` specifies the number of characters at which to wrap the content of the Operator column.
-  - The tree won't be broken even when lines are wrapped.
+  - The tree won't be broken even when operator lines are wrapped.
+- `--appendix-wrap-width` specifies the number of characters at which to wrap appendix lines.
+  - This is independent from `--wrap-width` because appendix lines do not include the tree/table layout.
 - `--hanging-indent` enables hanging indent for wrapped lines.
   - Wrapped continuation lines align after node-local prefixes such as `[Input] ` and `[Map] `.
   - Without this flag, wrapped lines keep the original tree-aligned indentation.
@@ -280,6 +290,7 @@ $ rendertree --compact --wrap-width=60 < testdata/distributed_cross_apply.yaml
 |  18 |      +Index Scan on SongsBySongGenre<Row>(Full scan,scan_met |
 |     |       hod:Row)                                               |
 +-----+--------------------------------------------------------------+
+
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"log/slog"
+	"maps"
 	"os"
 	"regexp"
 	"slices"
@@ -175,6 +176,11 @@ var (
 )
 
 var secsRe = regexp.MustCompile(`secs$`)
+
+var (
+	scalarVariableReferenceRe   = regexp.MustCompile(`\$[A-Za-z0-9_']+`)
+	scalarVariableDescriptionRe = regexp.MustCompile(`^\$[A-Za-z0-9_']+$`)
+)
 
 func secsToS(v any) string {
 	return secsRe.ReplaceAllString(fmt.Sprint(v), "s")
@@ -854,21 +860,13 @@ func (r scalarLinkResolver) formatAggregateScalarLink(link plantree.ScalarChildL
 }
 
 func (r scalarLinkResolver) resolveKeyDescription(desc string) string {
-	return r.resolveKeyDescriptionSeen(desc, map[string]bool{})
+	return normalizeKeyOrderSuffix(r.resolveDescriptionVariables(desc, map[string]bool{}))
 }
 
-func (r scalarLinkResolver) resolveKeyDescriptionSeen(desc string, seen map[string]bool) string {
-	first, last, found := strings.Cut(desc, " ")
-	keyElem := r.lookupVar(strings.TrimSpace(first), seen)
-	if !found {
-		return keyElem
-	}
-
-	suffix := normalizeKeySuffix(last)
-	if suffix == "" {
-		return keyElem
-	}
-	return keyElem + " " + suffix
+func (r scalarLinkResolver) resolveDescriptionVariables(desc string, seen map[string]bool) string {
+	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
+		return r.lookupVar(ref, seen)
+	})
 }
 
 func (r scalarLinkResolver) lookupVar(ref string, seen map[string]bool) string {
@@ -886,17 +884,21 @@ func (r scalarLinkResolver) lookupVar(ref string, seen map[string]bool) string {
 		return ref
 	}
 
-	seen[varName] = true
-	return r.resolveKeyDescriptionSeen(desc, seen)
+	nextSeen := maps.Clone(seen)
+	nextSeen[varName] = true
+	desc = strings.TrimSpace(desc)
+	if scalarVariableDescriptionRe.MatchString(desc) {
+		return r.lookupVar(desc, nextSeen)
+	}
+	return desc
 }
 
-func normalizeKeySuffix(s string) string {
+func normalizeKeyOrderSuffix(s string) string {
 	s = strings.TrimSpace(s)
-	if s == "" {
-		return ""
-	}
-	if strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") {
-		return strings.TrimSuffix(strings.TrimPrefix(s, "("), ")")
+	for _, suffix := range []string{"(ASC)", "(DESC)"} {
+		if strings.HasSuffix(s, " "+suffix) {
+			return strings.TrimSuffix(s, " "+suffix) + " " + strings.Trim(suffix, "()")
+		}
 	}
 	return s
 }

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -347,6 +347,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	compact := flagSet.Bool("compact", false, "Enable compact format")
 	inlineStats := flagSet.Bool("inline-stats", false, "Enable inline stats")
 	wrapWidth := flagSet.Int("wrap-width", 0, "Number of characters at which to wrap the Operator column content. 0 means no wrapping.")
+	appendixWrapWidth := flagSet.Int("appendix-wrap-width", 0, "Number of characters at which to wrap appendix lines. 0 means no wrapping.")
 	hangingIndent := flagSet.Bool("hanging-indent", false, "Enable hanging indent for wrapped lines after node-local prefixes such as [Input] and [Map]")
 
 	var custom stringList
@@ -509,6 +510,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		resolveScalarVarsRecursive: *resolveScalarVarsRecursive,
 		disallowUnknownStats:       *disallowUnknownStats,
 		inlineStats:                *inlineStats,
+		appendixWrapWidth:          *appendixWrapWidth,
 		plantreeOptions:            opts,
 	})
 	if err != nil {
@@ -527,6 +529,7 @@ type renderTreeOptions struct {
 	resolveScalarVarsRecursive bool
 	disallowUnknownStats       bool
 	inlineStats                bool
+	appendixWrapWidth          int
 	plantreeOptions            []plantree.Option
 }
 
@@ -557,6 +560,7 @@ func renderTreeImpl(planNodes []*sppb.PlanNode, renderOpts renderTreeOptions) (s
 		showScalarVars:             renderOpts.showScalarVars,
 		resolveScalarVars:          renderOpts.resolveScalarVars,
 		resolveScalarVarsRecursive: renderOpts.resolveScalarVarsRecursive,
+		appendixWrapWidth:          renderOpts.appendixWrapWidth,
 	})
 	if err != nil {
 		return "", err
@@ -721,6 +725,7 @@ type printResultOptions struct {
 	showScalarVars             bool
 	resolveScalarVars          bool
 	resolveScalarVarsRecursive bool
+	appendixWrapWidth          int
 }
 
 func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions) (string, error) {
@@ -748,6 +753,7 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 		case PrintFull, PrintTyped:
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Node Parameters(identified by ID):",
+				printOpts.appendixWrapWidth,
 				func(row plantree.RowWithPredicates) []string {
 					return scalarLinkLines(row, func(_ plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
 						return section == PrintFull || link.Type != ""
@@ -757,6 +763,7 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 		case PrintPredicates:
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Predicates(identified by ID):",
+				printOpts.appendixWrapWidth,
 				func(row plantree.RowWithPredicates) []string {
 					return row.Predicates
 				},
@@ -770,6 +777,7 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Ordering(identified by ID):",
+				printOpts.appendixWrapWidth,
 				func(row plantree.RowWithPredicates) []string {
 					return scalarLinkLines(row, isOrderingScalarLink, format)
 				},
@@ -783,6 +791,7 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Aggregates(identified by ID):",
+				printOpts.appendixWrapWidth,
 				func(row plantree.RowWithPredicates) []string {
 					return scalarLinkLines(row, isAggregateScalarLink, format)
 				},
@@ -793,7 +802,12 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 		if err != nil {
 			return "", err
 		}
-		b.WriteString(part)
+		if part != "" {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(part)
+		}
 	}
 	return b.String(), nil
 }
@@ -802,7 +816,7 @@ func needsScalarLinkResolver(printSections PrintSections) bool {
 	return slices.Contains(printSections, PrintOrdering) || slices.Contains(printSections, PrintAggregate)
 }
 
-func scalarAppendixSpec(title string, items func(row plantree.RowWithPredicates) []string) asciitable.AppendixSpec[plantree.RowWithPredicates] {
+func scalarAppendixSpec(title string, appendixWrapWidth int, items func(row plantree.RowWithPredicates) []string) asciitable.AppendixSpec[plantree.RowWithPredicates] {
 	return asciitable.AppendixSpec[plantree.RowWithPredicates]{
 		Title: title,
 		ID: func(row plantree.RowWithPredicates) uint {
@@ -810,7 +824,8 @@ func scalarAppendixSpec(title string, items func(row plantree.RowWithPredicates)
 			// non-negative when used as appendix display IDs.
 			return uint(row.ID)
 		},
-		Items: items,
+		Items:     items,
+		WrapWidth: appendixWrapWidth,
 	}
 }
 

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -347,7 +347,6 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	compact := flagSet.Bool("compact", false, "Enable compact format")
 	inlineStats := flagSet.Bool("inline-stats", false, "Enable inline stats")
 	wrapWidth := flagSet.Int("wrap-width", 0, "Number of characters at which to wrap the Operator column content. 0 means no wrapping.")
-	appendixWrapWidth := flagSet.Int("appendix-wrap-width", 0, "Number of characters at which to wrap appendix lines. 0 means no wrapping.")
 	hangingIndent := flagSet.Bool("hanging-indent", false, "Enable hanging indent for wrapped lines after node-local prefixes such as [Input] and [Map]")
 
 	var custom stringList
@@ -510,7 +509,6 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		resolveScalarVarsRecursive: *resolveScalarVarsRecursive,
 		disallowUnknownStats:       *disallowUnknownStats,
 		inlineStats:                *inlineStats,
-		appendixWrapWidth:          *appendixWrapWidth,
 		plantreeOptions:            opts,
 	})
 	if err != nil {
@@ -529,7 +527,6 @@ type renderTreeOptions struct {
 	resolveScalarVarsRecursive bool
 	disallowUnknownStats       bool
 	inlineStats                bool
-	appendixWrapWidth          int
 	plantreeOptions            []plantree.Option
 }
 
@@ -560,7 +557,6 @@ func renderTreeImpl(planNodes []*sppb.PlanNode, renderOpts renderTreeOptions) (s
 		showScalarVars:             renderOpts.showScalarVars,
 		resolveScalarVars:          renderOpts.resolveScalarVars,
 		resolveScalarVarsRecursive: renderOpts.resolveScalarVarsRecursive,
-		appendixWrapWidth:          renderOpts.appendixWrapWidth,
 	})
 	if err != nil {
 		return "", err
@@ -725,7 +721,6 @@ type printResultOptions struct {
 	showScalarVars             bool
 	resolveScalarVars          bool
 	resolveScalarVarsRecursive bool
-	appendixWrapWidth          int
 }
 
 func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions) (string, error) {
@@ -753,7 +748,6 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 		case PrintFull, PrintTyped:
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Node Parameters(identified by ID):",
-				printOpts.appendixWrapWidth,
 				func(row plantree.RowWithPredicates) []string {
 					return scalarLinkLines(row, func(_ plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
 						return section == PrintFull || link.Type != ""
@@ -763,7 +757,6 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 		case PrintPredicates:
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Predicates(identified by ID):",
-				printOpts.appendixWrapWidth,
 				func(row plantree.RowWithPredicates) []string {
 					return row.Predicates
 				},
@@ -777,7 +770,6 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Ordering(identified by ID):",
-				printOpts.appendixWrapWidth,
 				func(row plantree.RowWithPredicates) []string {
 					return scalarLinkLines(row, isOrderingScalarLink, format)
 				},
@@ -791,7 +783,6 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Aggregates(identified by ID):",
-				printOpts.appendixWrapWidth,
 				func(row plantree.RowWithPredicates) []string {
 					return scalarLinkLines(row, isAggregateScalarLink, format)
 				},
@@ -816,7 +807,7 @@ func needsScalarLinkResolver(printSections PrintSections) bool {
 	return slices.Contains(printSections, PrintOrdering) || slices.Contains(printSections, PrintAggregate)
 }
 
-func scalarAppendixSpec(title string, appendixWrapWidth int, items func(row plantree.RowWithPredicates) []string) asciitable.AppendixSpec[plantree.RowWithPredicates] {
+func scalarAppendixSpec(title string, items func(row plantree.RowWithPredicates) []string) asciitable.AppendixSpec[plantree.RowWithPredicates] {
 	return asciitable.AppendixSpec[plantree.RowWithPredicates]{
 		Title: title,
 		ID: func(row plantree.RowWithPredicates) uint {
@@ -824,8 +815,7 @@ func scalarAppendixSpec(title string, appendixWrapWidth int, items func(row plan
 			// non-negative when used as appendix display IDs.
 			return uint(row.ID)
 		},
-		Items:     items,
-		WrapWidth: appendixWrapWidth,
+		Items: items,
 	}
 }
 

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -501,7 +501,16 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		renderDef = withStatsToRenderDefMap[withStats]
 	}
 
-	s, err := renderTreeImpl(planNodes, renderDef, printSections, *showScalarVars, *resolveScalarVars, *resolveScalarVarsRecursive, *disallowUnknownStats, *inlineStats, opts)
+	s, err := renderTreeImpl(planNodes, renderTreeOptions{
+		renderDef:                  renderDef,
+		printSections:              printSections,
+		showScalarVars:             *showScalarVars,
+		resolveScalarVars:          *resolveScalarVars,
+		resolveScalarVarsRecursive: *resolveScalarVarsRecursive,
+		disallowUnknownStats:       *disallowUnknownStats,
+		inlineStats:                *inlineStats,
+		plantreeOptions:            opts,
+	})
 	if err != nil {
 		return err
 	}
@@ -510,10 +519,22 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	return err
 }
 
-func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printSections PrintSections, showScalarVars bool, resolveScalarVars bool, resolveScalarVarsRecursive bool, disallowUnknownStats bool, inline bool, opts []plantree.Option) (string, error) {
-	opts = append(opts,
+type renderTreeOptions struct {
+	renderDef                  tableRenderDef
+	printSections              PrintSections
+	showScalarVars             bool
+	resolveScalarVars          bool
+	resolveScalarVarsRecursive bool
+	disallowUnknownStats       bool
+	inlineStats                bool
+	plantreeOptions            []plantree.Option
+}
+
+func renderTreeImpl(planNodes []*sppb.PlanNode, renderOpts renderTreeOptions) (string, error) {
+	plantreeOptions := slices.Clone(renderOpts.plantreeOptions)
+	plantreeOptions = append(plantreeOptions,
 		plantree.WithQueryPlanOptions(
-			spannerplan.WithInlineStatsFunc(inlineStatsFuncFromTableRenderDef(disallowUnknownStats, renderDef, inline)),
+			spannerplan.WithInlineStatsFunc(inlineStatsFuncFromTableRenderDef(renderOpts.disallowUnknownStats, renderOpts.renderDef, renderOpts.inlineStats)),
 		))
 
 	qp, err := spannerplan.New(planNodes)
@@ -521,18 +542,22 @@ func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printS
 		return "", err
 	}
 
-	rows, err := plantree.ProcessPlan(qp, opts...)
+	rows, err := plantree.ProcessPlan(qp, plantreeOptions...)
 	if err != nil {
 		return "", err
 	}
 
-	s, err := printResult(
-		tableRenderDef{
-			Columns: lo.Filter(renderDef.Columns, func(def columnRenderDef, index int) bool {
-				return !def.shouldInline(inline)
+	s, err := printResult(rows, printResultOptions{
+		renderDef: tableRenderDef{
+			Columns: lo.Filter(renderOpts.renderDef.Columns, func(def columnRenderDef, index int) bool {
+				return !def.shouldInline(renderOpts.inlineStats)
 			}),
 		},
-		rows, printSections, showScalarVars, resolveScalarVars, resolveScalarVarsRecursive)
+		printSections:              renderOpts.printSections,
+		showScalarVars:             renderOpts.showScalarVars,
+		resolveScalarVars:          renderOpts.resolveScalarVars,
+		resolveScalarVarsRecursive: renderOpts.resolveScalarVarsRecursive,
+	})
 	if err != nil {
 		return "", err
 	}
@@ -690,23 +715,31 @@ func customListToTableRenderDef(custom []string) (tableRenderDef, error) {
 	return tableRenderDef{Columns: columns}, nil
 }
 
-func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, printSections PrintSections, showScalarVars bool, resolveScalarVars bool, resolveScalarVarsRecursive bool) (string, error) {
+type printResultOptions struct {
+	renderDef                  tableRenderDef
+	printSections              PrintSections
+	showScalarVars             bool
+	resolveScalarVars          bool
+	resolveScalarVarsRecursive bool
+}
+
+func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions) (string, error) {
 	var b strings.Builder
-	resolveVars := resolveScalarVars || resolveScalarVarsRecursive
+	resolveVars := printOpts.resolveScalarVars || printOpts.resolveScalarVarsRecursive
 	var resolver scalarLinkResolver
-	if resolveVars && needsScalarLinkResolver(printSections) {
+	if resolveVars && needsScalarLinkResolver(printOpts.printSections) {
 		resolver = newScalarLinkResolver(rows)
 	}
 
-	if len(rows) > 0 && len(renderDef.Columns) > 0 {
-		tablePart, err := renderTablePart(renderDef, rows)
+	if len(rows) > 0 && len(printOpts.renderDef.Columns) > 0 {
+		tablePart, err := renderTablePart(printOpts.renderDef, rows)
 		if err != nil {
 			return "", err
 		}
 		b.WriteString(tablePart)
 	}
 
-	for _, section := range printSections {
+	for _, section := range printOpts.printSections {
 		var (
 			part string
 			err  error
@@ -729,10 +762,10 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 				},
 			))
 		case PrintOrdering:
-			format := semanticScalarLinkFormatter(showScalarVars, scalarLinkDescription)
+			format := semanticScalarLinkFormatter(printOpts.showScalarVars, scalarLinkDescription)
 			if resolveVars {
-				format = semanticScalarLinkFormatter(showScalarVars, func(link plantree.ScalarChildLink) string {
-					return resolver.formatKeyScalarLink(link, resolveScalarVarsRecursive)
+				format = semanticScalarLinkFormatter(printOpts.showScalarVars, func(link plantree.ScalarChildLink) string {
+					return resolver.formatKeyScalarLink(link, printOpts.resolveScalarVarsRecursive)
 				})
 			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
@@ -742,10 +775,10 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 				},
 			))
 		case PrintAggregate:
-			format := semanticScalarLinkFormatter(showScalarVars, scalarLinkDescription)
+			format := semanticScalarLinkFormatter(printOpts.showScalarVars, scalarLinkDescription)
 			if resolveVars {
-				format = semanticScalarLinkFormatter(showScalarVars, func(link plantree.ScalarChildLink) string {
-					return resolver.formatAggregateScalarLink(link, resolveScalarVarsRecursive)
+				format = semanticScalarLinkFormatter(printOpts.showScalarVars, func(link plantree.ScalarChildLink) string {
+					return resolver.formatAggregateScalarLink(link, printOpts.resolveScalarVarsRecursive)
 				})
 			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"log/slog"
-	"maps"
 	"os"
 	"regexp"
 	"slices"
@@ -904,16 +903,32 @@ func (r scalarLinkResolver) formatAggregateScalarLink(link plantree.ScalarChildL
 }
 
 func (r scalarLinkResolver) resolveKeyDescription(desc string, recursive bool) string {
-	return normalizeKeyOrderSuffix(r.resolveDescriptionVariables(desc, map[string]bool{}, recursive))
+	if !recursive {
+		return normalizeKeyOrderSuffix(r.resolveDirectDescriptionVariables(desc))
+	}
+	return normalizeKeyOrderSuffix(r.resolveDescriptionVariables(desc, map[string]bool{}))
 }
 
-func (r scalarLinkResolver) resolveDescriptionVariables(desc string, seen map[string]bool, recursive bool) string {
+func (r scalarLinkResolver) resolveDirectDescriptionVariables(desc string) string {
 	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
-		return r.lookupVar(ref, seen, recursive)
+		if !strings.HasPrefix(ref, "$") {
+			return ref
+		}
+		desc, ok := r.variableToDescription[strings.TrimPrefix(ref, "$")]
+		if !ok {
+			return ref
+		}
+		return strings.TrimSpace(desc)
 	})
 }
 
-func (r scalarLinkResolver) lookupVar(ref string, seen map[string]bool, recursive bool) string {
+func (r scalarLinkResolver) resolveDescriptionVariables(desc string, seen map[string]bool) string {
+	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
+		return r.lookupVarRecursive(ref, seen)
+	})
+}
+
+func (r scalarLinkResolver) lookupVarRecursive(ref string, seen map[string]bool) string {
 	if !strings.HasPrefix(ref, "$") {
 		return ref
 	}
@@ -928,16 +943,14 @@ func (r scalarLinkResolver) lookupVar(ref string, seen map[string]bool, recursiv
 		return ref
 	}
 
-	nextSeen := maps.Clone(seen)
-	nextSeen[varName] = true
+	seen[varName] = true
+	defer delete(seen, varName)
+
 	desc = strings.TrimSpace(desc)
-	if !recursive {
-		return desc
-	}
 	if scalarVariableDescriptionRe.MatchString(desc) {
-		return r.lookupVar(desc, nextSeen, true)
+		return r.lookupVarRecursive(desc, seen)
 	}
-	return r.resolveDescriptionVariables(desc, nextSeen, true)
+	return r.resolveDescriptionVariables(desc, seen)
 }
 
 func normalizeKeyOrderSuffix(s string) string {

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -761,7 +761,7 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 				},
 			))
 		case PrintOrdering:
-			format := semanticScalarLinkFormatter(printOpts.showScalarVars, scalarLinkDescription)
+			format := semanticScalarLinkFormatter(printOpts.showScalarVars, keyScalarLinkDescription)
 			if resolveVars {
 				format = semanticScalarLinkFormatter(printOpts.showScalarVars, func(link plantree.ScalarChildLink) string {
 					return resolver.formatKeyScalarLink(link, printOpts.resolveScalarVarsRecursive)
@@ -862,6 +862,10 @@ func formatRawScalarLink(link plantree.ScalarChildLink) string {
 
 func scalarLinkDescription(link plantree.ScalarChildLink) string {
 	return link.Description
+}
+
+func keyScalarLinkDescription(link plantree.ScalarChildLink) string {
+	return normalizeKeyOrderSuffix(link.Description)
 }
 
 func semanticScalarLinkFormatter(showVars bool, description func(plantree.ScalarChildLink) string) func(plantree.ScalarChildLink) string {

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -177,8 +177,8 @@ var (
 var secsRe = regexp.MustCompile(`secs$`)
 
 var (
-	scalarVariableReferenceRe   = regexp.MustCompile(`\$[A-Za-z0-9_']+`)
-	scalarVariableDescriptionRe = regexp.MustCompile(`^\$[A-Za-z0-9_']+$`)
+	scalarVariableReferenceRe   = regexp.MustCompile(`\$[A-Za-z0-9_']+(?:\.[A-Za-z0-9_']+)*`)
+	scalarVariableDescriptionRe = regexp.MustCompile(`^\$[A-Za-z0-9_']+(?:\.[A-Za-z0-9_']+)*$`)
 )
 
 func secsToS(v any) string {

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -338,6 +338,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	printSectionsStr := flagSet.String("print", "predicates", "print appendix sections: predicates, ordering, aggregate, typed, full (comma-separated; typed/full are raw debug dumps)")
 	showScalarVars := flagSet.Bool("show-vars", false, "show scalar variable assignments in semantic appendix sections")
 	resolveScalarVars := flagSet.Bool("resolve-vars", false, "EXPERIMENTAL: resolve scalar variable aliases in semantic appendix sections")
+	resolveScalarVarsRecursive := flagSet.Bool("resolve-vars-recursive", false, "EXPERIMENTAL: recursively resolve scalar variable aliases in semantic appendix sections")
 	disallowUnknownStats := flagSet.Bool("disallow-unknown-stats", false, "error on unknown stats field")
 	executionMethod := flagSet.String("execution-method", "angle", "Format execution method metadata: 'angle' or 'raw' (default: angle)")
 	targetMetadata := flagSet.String("target-metadata", "on", "Format target metadata: 'on' or 'raw' (default: on)")
@@ -500,7 +501,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		renderDef = withStatsToRenderDefMap[withStats]
 	}
 
-	s, err := renderTreeImpl(planNodes, renderDef, printSections, *showScalarVars, *resolveScalarVars, *disallowUnknownStats, *inlineStats, opts)
+	s, err := renderTreeImpl(planNodes, renderDef, printSections, *showScalarVars, *resolveScalarVars, *resolveScalarVarsRecursive, *disallowUnknownStats, *inlineStats, opts)
 	if err != nil {
 		return err
 	}
@@ -509,7 +510,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	return err
 }
 
-func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printSections PrintSections, showScalarVars bool, resolveScalarVars bool, disallowUnknownStats bool, inline bool, opts []plantree.Option) (string, error) {
+func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printSections PrintSections, showScalarVars bool, resolveScalarVars bool, resolveScalarVarsRecursive bool, disallowUnknownStats bool, inline bool, opts []plantree.Option) (string, error) {
 	opts = append(opts,
 		plantree.WithQueryPlanOptions(
 			spannerplan.WithInlineStatsFunc(inlineStatsFuncFromTableRenderDef(disallowUnknownStats, renderDef, inline)),
@@ -531,7 +532,7 @@ func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printS
 				return !def.shouldInline(inline)
 			}),
 		},
-		rows, printSections, showScalarVars, resolveScalarVars)
+		rows, printSections, showScalarVars, resolveScalarVars, resolveScalarVarsRecursive)
 	if err != nil {
 		return "", err
 	}
@@ -689,10 +690,11 @@ func customListToTableRenderDef(custom []string) (tableRenderDef, error) {
 	return tableRenderDef{Columns: columns}, nil
 }
 
-func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, printSections PrintSections, showScalarVars bool, resolveScalarVars bool) (string, error) {
+func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, printSections PrintSections, showScalarVars bool, resolveScalarVars bool, resolveScalarVarsRecursive bool) (string, error) {
 	var b strings.Builder
+	resolveVars := resolveScalarVars || resolveScalarVarsRecursive
 	var resolver scalarLinkResolver
-	if resolveScalarVars && needsScalarLinkResolver(printSections) {
+	if resolveVars && needsScalarLinkResolver(printSections) {
 		resolver = newScalarLinkResolver(rows)
 	}
 
@@ -728,8 +730,10 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 			))
 		case PrintOrdering:
 			format := semanticScalarLinkFormatter(showScalarVars, scalarLinkDescription)
-			if resolveScalarVars {
-				format = semanticScalarLinkFormatter(showScalarVars, resolver.formatKeyScalarLink)
+			if resolveVars {
+				format = semanticScalarLinkFormatter(showScalarVars, func(link plantree.ScalarChildLink) string {
+					return resolver.formatKeyScalarLink(link, resolveScalarVarsRecursive)
+				})
 			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Ordering(identified by ID):",
@@ -739,8 +743,10 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 			))
 		case PrintAggregate:
 			format := semanticScalarLinkFormatter(showScalarVars, scalarLinkDescription)
-			if resolveScalarVars {
-				format = semanticScalarLinkFormatter(showScalarVars, resolver.formatAggregateScalarLink)
+			if resolveVars {
+				format = semanticScalarLinkFormatter(showScalarVars, func(link plantree.ScalarChildLink) string {
+					return resolver.formatAggregateScalarLink(link, resolveScalarVarsRecursive)
+				})
 			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Aggregates(identified by ID):",
@@ -848,28 +854,28 @@ func newScalarLinkResolver(rows []plantree.RowWithPredicates) scalarLinkResolver
 	return scalarLinkResolver{variableToDescription: variableToDescription}
 }
 
-func (r scalarLinkResolver) formatKeyScalarLink(link plantree.ScalarChildLink) string {
-	return r.resolveKeyDescription(link.Description)
+func (r scalarLinkResolver) formatKeyScalarLink(link plantree.ScalarChildLink, recursive bool) string {
+	return r.resolveKeyDescription(link.Description, recursive)
 }
 
-func (r scalarLinkResolver) formatAggregateScalarLink(link plantree.ScalarChildLink) string {
+func (r scalarLinkResolver) formatAggregateScalarLink(link plantree.ScalarChildLink, recursive bool) string {
 	if link.Type == "Key" {
-		return r.resolveKeyDescription(link.Description)
+		return r.resolveKeyDescription(link.Description, recursive)
 	}
 	return link.Description
 }
 
-func (r scalarLinkResolver) resolveKeyDescription(desc string) string {
-	return normalizeKeyOrderSuffix(r.resolveDescriptionVariables(desc, map[string]bool{}))
+func (r scalarLinkResolver) resolveKeyDescription(desc string, recursive bool) string {
+	return normalizeKeyOrderSuffix(r.resolveDescriptionVariables(desc, map[string]bool{}, recursive))
 }
 
-func (r scalarLinkResolver) resolveDescriptionVariables(desc string, seen map[string]bool) string {
+func (r scalarLinkResolver) resolveDescriptionVariables(desc string, seen map[string]bool, recursive bool) string {
 	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
-		return r.lookupVar(ref, seen)
+		return r.lookupVar(ref, seen, recursive)
 	})
 }
 
-func (r scalarLinkResolver) lookupVar(ref string, seen map[string]bool) string {
+func (r scalarLinkResolver) lookupVar(ref string, seen map[string]bool, recursive bool) string {
 	if !strings.HasPrefix(ref, "$") {
 		return ref
 	}
@@ -887,10 +893,13 @@ func (r scalarLinkResolver) lookupVar(ref string, seen map[string]bool) string {
 	nextSeen := maps.Clone(seen)
 	nextSeen[varName] = true
 	desc = strings.TrimSpace(desc)
-	if scalarVariableDescriptionRe.MatchString(desc) {
-		return r.lookupVar(desc, nextSeen)
+	if !recursive {
+		return desc
 	}
-	return desc
+	if scalarVariableDescriptionRe.MatchString(desc) {
+		return r.lookupVar(desc, nextSeen, true)
+	}
+	return r.resolveDescriptionVariables(desc, nextSeen, true)
 }
 
 func normalizeKeyOrderSuffix(s string) string {

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -915,9 +915,6 @@ func (r scalarLinkResolver) resolveKeyDescription(desc string, recursive bool) s
 
 func (r scalarLinkResolver) resolveDirectDescriptionVariables(desc string) string {
 	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
-		if !strings.HasPrefix(ref, "$") {
-			return ref
-		}
 		desc, ok := r.variableToDescription[strings.TrimPrefix(ref, "$")]
 		if !ok {
 			return ref

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -330,7 +330,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file (mutually exclusive with --custom and --custom-column)")
 	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
 	printSectionsStr := flagSet.String("print", "predicates", "print appendix sections: predicates, ordering, aggregate, typed, full (comma-separated; typed/full are raw debug dumps)")
-	resolveScalarVars := flagSet.Bool("resolve-scalar-vars", false, "EXPERIMENTAL: resolve scalar variable aliases in semantic appendix sections")
+	resolveScalarVars := flagSet.Bool("resolve-vars", false, "EXPERIMENTAL: resolve scalar variable aliases in semantic appendix sections")
 	disallowUnknownStats := flagSet.Bool("disallow-unknown-stats", false, "error on unknown stats field")
 	executionMethod := flagSet.String("execution-method", "angle", "Format execution method metadata: 'angle' or 'raw' (default: angle)")
 	targetMetadata := flagSet.String("target-metadata", "on", "Format target metadata: 'on' or 'raw' (default: on)")

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -742,6 +742,8 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 					return scalarLinkLines(row, isAggregateScalarLink, format)
 				},
 			))
+		default:
+			return "", fmt.Errorf("unsupported print section: %s", section)
 		}
 		if err != nil {
 			return "", err

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -330,6 +330,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file (mutually exclusive with --custom and --custom-column)")
 	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
 	printSectionsStr := flagSet.String("print", "predicates", "print appendix sections: predicates, ordering, aggregate, typed, full (comma-separated; typed/full are raw debug dumps)")
+	resolveScalarVars := flagSet.Bool("resolve-scalar-vars", false, "EXPERIMENTAL: resolve scalar variable aliases in semantic appendix sections")
 	disallowUnknownStats := flagSet.Bool("disallow-unknown-stats", false, "error on unknown stats field")
 	executionMethod := flagSet.String("execution-method", "angle", "Format execution method metadata: 'angle' or 'raw' (default: angle)")
 	targetMetadata := flagSet.String("target-metadata", "on", "Format target metadata: 'on' or 'raw' (default: on)")
@@ -492,7 +493,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		renderDef = withStatsToRenderDefMap[withStats]
 	}
 
-	s, err := renderTreeImpl(planNodes, renderDef, printSections, *disallowUnknownStats, *inlineStats, opts)
+	s, err := renderTreeImpl(planNodes, renderDef, printSections, *resolveScalarVars, *disallowUnknownStats, *inlineStats, opts)
 	if err != nil {
 		return err
 	}
@@ -501,7 +502,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	return err
 }
 
-func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printSections PrintSections, disallowUnknownStats bool, inline bool, opts []plantree.Option) (string, error) {
+func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printSections PrintSections, resolveScalarVars bool, disallowUnknownStats bool, inline bool, opts []plantree.Option) (string, error) {
 	opts = append(opts,
 		plantree.WithQueryPlanOptions(
 			spannerplan.WithInlineStatsFunc(inlineStatsFuncFromTableRenderDef(disallowUnknownStats, renderDef, inline)),
@@ -523,7 +524,7 @@ func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printS
 				return !def.shouldInline(inline)
 			}),
 		},
-		rows, printSections)
+		rows, printSections, resolveScalarVars)
 	if err != nil {
 		return "", err
 	}
@@ -681,8 +682,9 @@ func customListToTableRenderDef(custom []string) (tableRenderDef, error) {
 	return tableRenderDef{Columns: columns}, nil
 }
 
-func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, printSections PrintSections) (string, error) {
+func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, printSections PrintSections, resolveScalarVars bool) (string, error) {
 	var b strings.Builder
+	resolver := newScalarLinkResolver(rows)
 
 	if len(rows) > 0 && len(renderDef.Columns) > 0 {
 		tablePart, err := renderTablePart(renderDef, rows)
@@ -704,7 +706,7 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 				func(row plantree.RowWithPredicates) []string {
 					return scalarLinkLines(row, func(_ plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
 						return section == PrintFull || link.Type != ""
-					})
+					}, formatRawScalarLink)
 				},
 			))
 		case PrintPredicates:
@@ -715,17 +717,25 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 				},
 			))
 		case PrintOrdering:
+			format := formatSemanticScalarLink
+			if resolveScalarVars {
+				format = resolver.formatKeyScalarLink
+			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Ordering(identified by ID):",
 				func(row plantree.RowWithPredicates) []string {
-					return scalarLinkLines(row, isOrderingScalarLink)
+					return scalarLinkLines(row, isOrderingScalarLink, format)
 				},
 			))
 		case PrintAggregate:
+			format := formatSemanticScalarLink
+			if resolveScalarVars {
+				format = resolver.formatAggregateScalarLink
+			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Aggregates(identified by ID):",
 				func(row plantree.RowWithPredicates) []string {
-					return scalarLinkLines(row, isAggregateScalarLink)
+					return scalarLinkLines(row, isAggregateScalarLink, format)
 				},
 			))
 		}
@@ -754,7 +764,7 @@ type scalarLinkGroup struct {
 	values []string
 }
 
-func scalarLinkLines(row plantree.RowWithPredicates, include func(plantree.RowWithPredicates, plantree.ScalarChildLink) bool) []string {
+func scalarLinkLines(row plantree.RowWithPredicates, include func(plantree.RowWithPredicates, plantree.ScalarChildLink) bool, format func(plantree.ScalarChildLink) string) []string {
 	groupByType := map[string]int{}
 	var groups []scalarLinkGroup
 
@@ -769,7 +779,7 @@ func scalarLinkLines(row plantree.RowWithPredicates, include func(plantree.RowWi
 			groupByType[link.Type] = groupIndex
 			groups = append(groups, scalarLinkGroup{typ: link.Type})
 		}
-		groups[groupIndex].values = append(groups[groupIndex].values, formatScalarLink(link))
+		groups[groupIndex].values = append(groups[groupIndex].values, format(link))
 	}
 
 	lines := make([]string, 0, len(groups))
@@ -784,11 +794,91 @@ func scalarLinkLines(row plantree.RowWithPredicates, include func(plantree.RowWi
 	return lines
 }
 
-func formatScalarLink(link plantree.ScalarChildLink) string {
+func formatRawScalarLink(link plantree.ScalarChildLink) string {
 	if link.Variable != "" {
 		return fmt.Sprintf("$%s=%s", link.Variable, link.Description)
 	}
 	return link.Description
+}
+
+func formatSemanticScalarLink(link plantree.ScalarChildLink) string {
+	return link.Description
+}
+
+type scalarLinkResolver struct {
+	variableToDescription map[string]string
+}
+
+func newScalarLinkResolver(rows []plantree.RowWithPredicates) scalarLinkResolver {
+	variableToDescription := map[string]string{}
+	for _, row := range rows {
+		for _, link := range row.ScalarChildLinks {
+			if link.Variable == "" {
+				continue
+			}
+			variableToDescription[link.Variable] = link.Description
+		}
+	}
+	return scalarLinkResolver{variableToDescription: variableToDescription}
+}
+
+func (r scalarLinkResolver) formatKeyScalarLink(link plantree.ScalarChildLink) string {
+	return r.resolveKeyDescription(link.Description)
+}
+
+func (r scalarLinkResolver) formatAggregateScalarLink(link plantree.ScalarChildLink) string {
+	if link.Type == "Key" {
+		return r.resolveKeyDescription(link.Description)
+	}
+	return link.Description
+}
+
+func (r scalarLinkResolver) resolveKeyDescription(desc string) string {
+	return r.resolveKeyDescriptionSeen(desc, map[string]bool{})
+}
+
+func (r scalarLinkResolver) resolveKeyDescriptionSeen(desc string, seen map[string]bool) string {
+	first, last, found := strings.Cut(desc, " ")
+	keyElem := r.lookupVar(strings.TrimSpace(first), seen)
+	if !found {
+		return keyElem
+	}
+
+	suffix := normalizeKeySuffix(last)
+	if suffix == "" {
+		return keyElem
+	}
+	return keyElem + " " + suffix
+}
+
+func (r scalarLinkResolver) lookupVar(ref string, seen map[string]bool) string {
+	if !strings.HasPrefix(ref, "$") {
+		return ref
+	}
+
+	varName := strings.TrimPrefix(ref, "$")
+	if seen[varName] {
+		return ref
+	}
+
+	desc, ok := r.variableToDescription[varName]
+	if !ok {
+		return ref
+	}
+
+	seen[varName] = true
+	return r.resolveKeyDescriptionSeen(desc, seen)
+}
+
+func normalizeKeySuffix(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") {
+		return strings.TrimSuffix(strings.TrimPrefix(s, "("), ")")
+	}
+	return s
 }
 
 func isOrderingScalarLink(row plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -1,7 +1,6 @@
 package impl
 
 import (
-	"cmp"
 	"errors"
 	"flag"
 	"fmt"
@@ -181,14 +180,6 @@ func secsToS(v any) string {
 	return secsRe.ReplaceAllString(fmt.Sprint(v), "s")
 }
 
-func sortedChildLinkEntries(m map[string][]*spannerplan.ResolvedChildLink) []lo.Entry[string, []*spannerplan.ResolvedChildLink] {
-	entries := lo.Entries(m)
-	slices.SortFunc(entries, func(a, b lo.Entry[string, []*spannerplan.ResolvedChildLink]) int {
-		return cmp.Compare(a.Key, b.Key)
-	})
-	return entries
-}
-
 var (
 	withStatsToRenderDefMap = map[bool]tableRenderDef{
 		false: {
@@ -248,25 +239,67 @@ func (s *repeatableStringList) Set(s2 string) error {
 
 const jsonSnippetLen = 140
 
-type PrintMode int
+// PrintSection selects one appendix section printed after the rendered tree.
+type PrintSection string
 
 const (
-	PrintPredicates PrintMode = iota
-	PrintTyped
-	PrintFull
+	// PrintPredicates prints predicate-like scalar links.
+	PrintPredicates PrintSection = "predicates"
+	// PrintOrdering prints ordering scalar links for sort operators.
+	PrintOrdering PrintSection = "ordering"
+	// PrintAggregate prints grouping and aggregate scalar links for aggregate operators.
+	PrintAggregate PrintSection = "aggregate"
+	// PrintTyped prints all typed scalar links as a raw debug dump.
+	PrintTyped PrintSection = "typed"
+	// PrintFull prints all scalar links, including unnamed links, as a raw debug dump.
+	PrintFull PrintSection = "full"
 )
 
-func parsePrintMode(s string) (PrintMode, error) {
-	switch strings.ToLower(s) {
-	case "predicates":
-		return PrintPredicates, nil
-	case "typed":
-		return PrintTyped, nil
-	case "full":
-		return PrintFull, nil
-	default:
-		return 0, fmt.Errorf("unknown PrintMode: %s", s)
+// PrintSections is the ordered list of appendix sections requested by the CLI.
+type PrintSections []PrintSection
+
+func parsePrintSections(s string) (PrintSections, error) {
+	var sections PrintSections
+	seen := map[PrintSection]bool{}
+	for _, raw := range strings.Split(s, ",") {
+		part := strings.TrimSpace(strings.ToLower(raw))
+		if part == "" {
+			return nil, fmt.Errorf("print section must not be empty")
+		}
+
+		var section PrintSection
+		switch part {
+		case string(PrintPredicates):
+			section = PrintPredicates
+		case string(PrintOrdering):
+			section = PrintOrdering
+		case string(PrintAggregate):
+			section = PrintAggregate
+		case string(PrintTyped):
+			section = PrintTyped
+		case string(PrintFull):
+			section = PrintFull
+		default:
+			return nil, fmt.Errorf("unknown print section: %s", raw)
+		}
+
+		if seen[section] {
+			return nil, fmt.Errorf("duplicate print section: %s", section)
+		}
+		seen[section] = true
+		sections = append(sections, section)
 	}
+
+	if len(sections) == 0 {
+		return nil, fmt.Errorf("print section must not be empty")
+	}
+
+	for _, section := range sections {
+		if (section == PrintTyped || section == PrintFull) && len(sections) > 1 {
+			return nil, fmt.Errorf("print section %q cannot be combined with other sections", section)
+		}
+	}
+	return sections, nil
 }
 
 type explainMode string
@@ -296,7 +329,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 
 	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file (mutually exclusive with --custom and --custom-column)")
 	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
-	printModeStr := flagSet.String("print", "predicates", "print node parameters(EXPERIMENTAL)")
+	printSectionsStr := flagSet.String("print", "predicates", "print appendix sections: predicates, ordering, aggregate, typed, full (comma-separated; typed/full are raw debug dumps)")
 	disallowUnknownStats := flagSet.Bool("disallow-unknown-stats", false, "error on unknown stats field")
 	executionMethod := flagSet.String("execution-method", "angle", "Format execution method metadata: 'angle' or 'raw' (default: angle)")
 	targetMetadata := flagSet.String("target-metadata", "on", "Format target metadata: 'on' or 'raw' (default: on)")
@@ -355,7 +388,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		_, _ = fmt.Fprintln(stderr, "--custom is deprecated. You must migrate to --custom-column or --custom-file.")
 	}
 
-	printMode, err := parsePrintMode(*printModeStr)
+	printSections, err := parsePrintSections(*printSectionsStr)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "Invalid value for -print flag: %v\n", err)
 		flagSet.Usage()
@@ -459,7 +492,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		renderDef = withStatsToRenderDefMap[withStats]
 	}
 
-	s, err := renderTreeImpl(planNodes, renderDef, printMode, *disallowUnknownStats, *inlineStats, opts)
+	s, err := renderTreeImpl(planNodes, renderDef, printSections, *disallowUnknownStats, *inlineStats, opts)
 	if err != nil {
 		return err
 	}
@@ -468,7 +501,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	return err
 }
 
-func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printMode PrintMode, disallowUnknownStats bool, inline bool, opts []plantree.Option) (string, error) {
+func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printSections PrintSections, disallowUnknownStats bool, inline bool, opts []plantree.Option) (string, error) {
 	opts = append(opts,
 		plantree.WithQueryPlanOptions(
 			spannerplan.WithInlineStatsFunc(inlineStatsFuncFromTableRenderDef(disallowUnknownStats, renderDef, inline)),
@@ -490,7 +523,7 @@ func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printM
 				return !def.shouldInline(inline)
 			}),
 		},
-		rows, printMode)
+		rows, printSections)
 	if err != nil {
 		return "", err
 	}
@@ -648,7 +681,7 @@ func customListToTableRenderDef(custom []string) (tableRenderDef, error) {
 	return tableRenderDef{Columns: columns}, nil
 }
 
-func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, printMode PrintMode) (string, error) {
+func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, printSections PrintSections) (string, error) {
 	var b strings.Builder
 
 	if len(rows) > 0 && len(renderDef.Columns) > 0 {
@@ -659,64 +692,118 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 		b.WriteString(tablePart)
 	}
 
-	switch printMode {
-	case PrintFull, PrintTyped:
-		parameters := parameterLines(rows, printMode)
-		if len(parameters) > 0 {
-			fmt.Fprintln(&b, "Node Parameters(identified by ID):")
-			for _, s := range parameters {
-				fmt.Fprintf(&b, " %s\n", s)
-			}
+	for _, section := range printSections {
+		var (
+			part string
+			err  error
+		)
+		switch section {
+		case PrintFull, PrintTyped:
+			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
+				"Node Parameters(identified by ID):",
+				func(row plantree.RowWithPredicates) []string {
+					return scalarLinkLines(row, func(_ plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
+						return section == PrintFull || link.Type != ""
+					})
+				},
+			))
+		case PrintPredicates:
+			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
+				"Predicates(identified by ID):",
+				func(row plantree.RowWithPredicates) []string {
+					return row.Predicates
+				},
+			))
+		case PrintOrdering:
+			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
+				"Ordering(identified by ID):",
+				func(row plantree.RowWithPredicates) []string {
+					return scalarLinkLines(row, isOrderingScalarLink)
+				},
+			))
+		case PrintAggregate:
+			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
+				"Aggregates(identified by ID):",
+				func(row plantree.RowWithPredicates) []string {
+					return scalarLinkLines(row, isAggregateScalarLink)
+				},
+			))
 		}
-	case PrintPredicates:
-		predPart, err := asciitable.RenderPredicates(rows, predicateSpec())
 		if err != nil {
 			return "", err
 		}
-		b.WriteString(predPart)
+		b.WriteString(part)
 	}
 	return b.String(), nil
 }
 
-func parameterLines(rows []plantree.RowWithPredicates, printMode PrintMode) []string {
-	var maxIDLength int
-	for _, row := range rows {
-		if length := len(fmt.Sprint(row.ID)); length > maxIDLength {
-			maxIDLength = length
+func scalarAppendixSpec(title string, items func(row plantree.RowWithPredicates) []string) asciitable.AppendixSpec[plantree.RowWithPredicates] {
+	return asciitable.AppendixSpec[plantree.RowWithPredicates]{
+		Title: title,
+		ID: func(row plantree.RowWithPredicates) uint {
+			// Spanner PlanNode indexes are zero-based node positions, so they are
+			// non-negative when used as appendix display IDs.
+			return uint(row.ID)
+		},
+		Items: items,
+	}
+}
+
+type scalarLinkGroup struct {
+	typ    string
+	values []string
+}
+
+func scalarLinkLines(row plantree.RowWithPredicates, include func(plantree.RowWithPredicates, plantree.ScalarChildLink) bool) []string {
+	groupByType := map[string]int{}
+	var groups []scalarLinkGroup
+
+	for _, link := range row.ScalarChildLinks {
+		if !include(row, link) {
+			continue
 		}
+
+		groupIndex, ok := groupByType[link.Type]
+		if !ok {
+			groupIndex = len(groups)
+			groupByType[link.Type] = groupIndex
+			groups = append(groups, scalarLinkGroup{typ: link.Type})
+		}
+		groups[groupIndex].values = append(groups[groupIndex].values, formatScalarLink(link))
 	}
 
-	var parameters []string
-	for _, row := range rows {
-		var prefix string
-		i := 0
-		for _, t := range sortedChildLinkEntries(row.ChildLinks) {
-			typ, childLinks := t.Key, t.Value
-			if printMode != PrintFull && typ == "" {
-				continue
-			}
-
-			if i == 0 {
-				prefix = fmt.Sprintf("%*d:", maxIDLength, row.ID)
-			} else {
-				prefix = strings.Repeat(" ", maxIDLength+1)
-			}
-
-			join := strings.Join(lo.Map(childLinks, func(item *spannerplan.ResolvedChildLink, index int) string {
-				if varName := item.ChildLink.GetVariable(); varName != "" {
-					return fmt.Sprintf("$%s=%s", item.ChildLink.GetVariable(), item.Child.GetShortRepresentation().GetDescription())
-				}
-				return item.Child.GetShortRepresentation().GetDescription()
-			}), ", ")
-			if join == "" {
-				continue
-			}
-			i++
-			typePartStr := lo.Ternary(typ != "", typ+": ", "")
-			parameters = append(parameters, fmt.Sprintf("%s %s%s", prefix, typePartStr, join))
+	lines := make([]string, 0, len(groups))
+	for _, group := range groups {
+		joined := strings.Join(group.values, ", ")
+		if joined == "" {
+			continue
 		}
+		typePartStr := lo.Ternary(group.typ != "", group.typ+": ", "")
+		lines = append(lines, typePartStr+joined)
 	}
-	return parameters
+	return lines
+}
+
+func formatScalarLink(link plantree.ScalarChildLink) string {
+	if link.Variable != "" {
+		return fmt.Sprintf("$%s=%s", link.Variable, link.Description)
+	}
+	return link.Description
+}
+
+func isOrderingScalarLink(row plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
+	switch row.DisplayName {
+	case "Sort", "Sort Limit":
+		return link.Type == "Key"
+	case "Minor Sort", "Minor Sort Limit":
+		return link.Type == "MajorKey" || link.Type == "MinorKey"
+	default:
+		return false
+	}
+}
+
+func isAggregateScalarLink(row plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
+	return row.DisplayName == "Aggregate" && (link.Type == "Key" || link.Type == "Agg")
 }
 
 type renderedTableRow []string
@@ -765,18 +852,5 @@ func tableAlignment(alignment tw.Align) (asciitable.Alignment, error) {
 		return asciitable.AlignLeft, nil
 	default:
 		return "", fmt.Errorf("unsupported alignment %v", alignment)
-	}
-}
-
-func predicateSpec() asciitable.PredicateSpec[plantree.RowWithPredicates] {
-	return asciitable.PredicateSpec[plantree.RowWithPredicates]{
-		ID: func(row plantree.RowWithPredicates) uint {
-			// Spanner PlanNode indexes are zero-based node positions, so they are
-			// non-negative when used as predicate appendix display IDs.
-			return uint(row.ID)
-		},
-		Predicates: func(row plantree.RowWithPredicates) []string {
-			return row.Predicates
-		},
 	}
 }

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -330,6 +330,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file (mutually exclusive with --custom and --custom-column)")
 	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
 	printSectionsStr := flagSet.String("print", "predicates", "print appendix sections: predicates, ordering, aggregate, typed, full (comma-separated; typed/full are raw debug dumps)")
+	showScalarVars := flagSet.Bool("show-vars", false, "show scalar variable assignments in semantic appendix sections")
 	resolveScalarVars := flagSet.Bool("resolve-vars", false, "EXPERIMENTAL: resolve scalar variable aliases in semantic appendix sections")
 	disallowUnknownStats := flagSet.Bool("disallow-unknown-stats", false, "error on unknown stats field")
 	executionMethod := flagSet.String("execution-method", "angle", "Format execution method metadata: 'angle' or 'raw' (default: angle)")
@@ -493,7 +494,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		renderDef = withStatsToRenderDefMap[withStats]
 	}
 
-	s, err := renderTreeImpl(planNodes, renderDef, printSections, *resolveScalarVars, *disallowUnknownStats, *inlineStats, opts)
+	s, err := renderTreeImpl(planNodes, renderDef, printSections, *showScalarVars, *resolveScalarVars, *disallowUnknownStats, *inlineStats, opts)
 	if err != nil {
 		return err
 	}
@@ -502,7 +503,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	return err
 }
 
-func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printSections PrintSections, resolveScalarVars bool, disallowUnknownStats bool, inline bool, opts []plantree.Option) (string, error) {
+func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printSections PrintSections, showScalarVars bool, resolveScalarVars bool, disallowUnknownStats bool, inline bool, opts []plantree.Option) (string, error) {
 	opts = append(opts,
 		plantree.WithQueryPlanOptions(
 			spannerplan.WithInlineStatsFunc(inlineStatsFuncFromTableRenderDef(disallowUnknownStats, renderDef, inline)),
@@ -524,7 +525,7 @@ func renderTreeImpl(planNodes []*sppb.PlanNode, renderDef tableRenderDef, printS
 				return !def.shouldInline(inline)
 			}),
 		},
-		rows, printSections, resolveScalarVars)
+		rows, printSections, showScalarVars, resolveScalarVars)
 	if err != nil {
 		return "", err
 	}
@@ -682,7 +683,7 @@ func customListToTableRenderDef(custom []string) (tableRenderDef, error) {
 	return tableRenderDef{Columns: columns}, nil
 }
 
-func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, printSections PrintSections, resolveScalarVars bool) (string, error) {
+func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, printSections PrintSections, showScalarVars bool, resolveScalarVars bool) (string, error) {
 	var b strings.Builder
 	resolver := newScalarLinkResolver(rows)
 
@@ -717,9 +718,9 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 				},
 			))
 		case PrintOrdering:
-			format := formatSemanticScalarLink
+			format := semanticScalarLinkFormatter(showScalarVars, scalarLinkDescription)
 			if resolveScalarVars {
-				format = resolver.formatKeyScalarLink
+				format = semanticScalarLinkFormatter(showScalarVars, resolver.formatKeyScalarLink)
 			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Ordering(identified by ID):",
@@ -728,9 +729,9 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 				},
 			))
 		case PrintAggregate:
-			format := formatSemanticScalarLink
+			format := semanticScalarLinkFormatter(showScalarVars, scalarLinkDescription)
 			if resolveScalarVars {
-				format = resolver.formatAggregateScalarLink
+				format = semanticScalarLinkFormatter(showScalarVars, resolver.formatAggregateScalarLink)
 			}
 			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
 				"Aggregates(identified by ID):",
@@ -801,8 +802,18 @@ func formatRawScalarLink(link plantree.ScalarChildLink) string {
 	return link.Description
 }
 
-func formatSemanticScalarLink(link plantree.ScalarChildLink) string {
+func scalarLinkDescription(link plantree.ScalarChildLink) string {
 	return link.Description
+}
+
+func semanticScalarLinkFormatter(showVars bool, description func(plantree.ScalarChildLink) string) func(plantree.ScalarChildLink) string {
+	return func(link plantree.ScalarChildLink) string {
+		desc := description(link)
+		if showVars && link.Variable != "" {
+			return fmt.Sprintf("$%s=%s", link.Variable, desc)
+		}
+		return desc
+	}
 }
 
 type scalarLinkResolver struct {

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -685,7 +685,10 @@ func customListToTableRenderDef(custom []string) (tableRenderDef, error) {
 
 func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, printSections PrintSections, showScalarVars bool, resolveScalarVars bool) (string, error) {
 	var b strings.Builder
-	resolver := newScalarLinkResolver(rows)
+	var resolver scalarLinkResolver
+	if resolveScalarVars && needsScalarLinkResolver(printSections) {
+		resolver = newScalarLinkResolver(rows)
+	}
 
 	if len(rows) > 0 && len(renderDef.Columns) > 0 {
 		tablePart, err := renderTablePart(renderDef, rows)
@@ -746,6 +749,10 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 		b.WriteString(part)
 	}
 	return b.String(), nil
+}
+
+func needsScalarLinkResolver(printSections PrintSections) bool {
+	return slices.Contains(printSections, PrintOrdering) || slices.Contains(printSections, PrintAggregate)
 }
 
 func scalarAppendixSpec(title string, items func(row plantree.RowWithPredicates) []string) asciitable.AppendixSpec[plantree.RowWithPredicates] {

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -513,6 +513,7 @@ func TestPrintResult_ResolveScalarVars(t *testing.T) {
 				{Type: "Key", Variable: "sort_count", Description: "$SongCount (DESC)"},
 				{Type: "Key", Variable: "sort_genre", Description: "$group_SongGenre'"},
 				{Type: "Key", Variable: "sort_expression", Description: "$left + $right"},
+				{Type: "Key", Variable: "sort_album", Description: "$v1.AlbumId_1"},
 			},
 		},
 		{
@@ -542,6 +543,7 @@ func TestPrintResult_ResolveScalarVars(t *testing.T) {
 				{Variable: "SingerId", Description: "SingerId"},
 				{Variable: "left", Description: "$SongGenre"},
 				{Variable: "right", Description: "$SingerId"},
+				{Variable: "v1.AlbumId_1", Description: "AlbumId"},
 			},
 		},
 	}
@@ -555,7 +557,7 @@ func TestPrintResult_ResolveScalarVars(t *testing.T) {
 	}
 	want := heredoc.Doc(`
 Ordering(identified by ID):
- 0: Key: COUNT_FINAL($v1) DESC, $group_SongGenre, $SongGenre + $SingerId
+ 0: Key: COUNT_FINAL($v1) DESC, $group_SongGenre, $SongGenre + $SingerId, AlbumId
 
 Aggregates(identified by ID):
  1: Key: $SongGenre
@@ -577,7 +579,7 @@ Aggregates(identified by ID):
 	}
 	want = heredoc.Doc(`
 Ordering(identified by ID):
- 0: Key: $sort_count=COUNT_FINAL($v1) DESC, $sort_genre=$group_SongGenre, $sort_expression=$SongGenre + $SingerId
+ 0: Key: $sort_count=COUNT_FINAL($v1) DESC, $sort_genre=$group_SongGenre, $sort_expression=$SongGenre + $SingerId, $sort_album=AlbumId
 
 Aggregates(identified by ID):
  1: Key: $group_SongGenre'=$SongGenre
@@ -598,7 +600,7 @@ Aggregates(identified by ID):
 	}
 	want = heredoc.Doc(`
 Ordering(identified by ID):
- 0: Key: COUNT_FINAL(COUNT()) DESC, SongGenre, SongGenre + SingerId
+ 0: Key: COUNT_FINAL(COUNT()) DESC, SongGenre, SongGenre + SingerId, AlbumId
 
 Aggregates(identified by ID):
  1: Key: SongGenre

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -404,7 +404,13 @@ Predicates(identified by ID):
 
 			opts = append(opts, tcase.opts...)
 
-			got, err := renderTreeImpl(stats.GetQueryPlan().GetPlanNodes(), tcase.renderDef, PrintSections{PrintPredicates}, false, false, false, true, tcase.inline, opts)
+			got, err := renderTreeImpl(stats.GetQueryPlan().GetPlanNodes(), renderTreeOptions{
+				renderDef:            tcase.renderDef,
+				printSections:        PrintSections{PrintPredicates},
+				disallowUnknownStats: true,
+				inlineStats:          tcase.inline,
+				plantreeOptions:      opts,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -448,7 +454,9 @@ func TestPrintResult_PrintSections(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintPredicates, PrintOrdering, PrintAggregate}, false, false, false)
+	got, err := printResult(rows, printResultOptions{
+		printSections: PrintSections{PrintPredicates, PrintOrdering, PrintAggregate},
+	})
 	if err != nil {
 		t.Fatalf("printResult() error = %v", err)
 	}
@@ -465,7 +473,10 @@ Aggregates(identified by ID):
 		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, true, false, false)
+	got, err = printResult(rows, printResultOptions{
+		printSections:  PrintSections{PrintOrdering, PrintAggregate},
+		showScalarVars: true,
+	})
 	if err != nil {
 		t.Fatalf("printResult(show vars) error = %v", err)
 	}
@@ -524,7 +535,10 @@ func TestPrintResult_ResolveScalarVars(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, false, true, false)
+	got, err := printResult(rows, printResultOptions{
+		printSections:     PrintSections{PrintOrdering, PrintAggregate},
+		resolveScalarVars: true,
+	})
 	if err != nil {
 		t.Fatalf("printResult() error = %v", err)
 	}
@@ -541,7 +555,11 @@ Aggregates(identified by ID):
 		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, true, true, false)
+	got, err = printResult(rows, printResultOptions{
+		printSections:     PrintSections{PrintOrdering, PrintAggregate},
+		showScalarVars:    true,
+		resolveScalarVars: true,
+	})
 	if err != nil {
 		t.Fatalf("printResult(show vars and resolve vars) error = %v", err)
 	}
@@ -558,7 +576,10 @@ Aggregates(identified by ID):
 		t.Fatalf("printResult(show vars and resolve vars) mismatch (-want +got):\n%s", diff)
 	}
 
-	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, false, false, true)
+	got, err = printResult(rows, printResultOptions{
+		printSections:              PrintSections{PrintOrdering, PrintAggregate},
+		resolveScalarVarsRecursive: true,
+	})
 	if err != nil {
 		t.Fatalf("printResult(resolve vars recursively) error = %v", err)
 	}
@@ -589,7 +610,9 @@ func TestPrintResult_RawPrintSections(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintTyped}, false, false, false)
+	got, err := printResult(rows, printResultOptions{
+		printSections: PrintSections{PrintTyped},
+	})
 	if err != nil {
 		t.Fatalf("printResult(typed) error = %v", err)
 	}
@@ -601,7 +624,9 @@ Node Parameters(identified by ID):
 		t.Fatalf("printResult(typed) mismatch (-want +got):\n%s", diff)
 	}
 
-	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintFull}, false, false, false)
+	got, err = printResult(rows, printResultOptions{
+		printSections: PrintSections{PrintFull},
+	})
 	if err != nil {
 		t.Fatalf("printResult(full) error = %v", err)
 	}
@@ -616,7 +641,9 @@ Node Parameters(identified by ID):
 }
 
 func TestPrintResult_UnsupportedPrintSection(t *testing.T) {
-	_, err := printResult(tableRenderDef{}, nil, PrintSections{"broken"}, false, false, false)
+	_, err := printResult(nil, printResultOptions{
+		printSections: PrintSections{"broken"},
+	})
 	if err == nil {
 		t.Fatal("printResult() error = nil, want non-nil")
 	}

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -113,6 +113,7 @@ func TestRenderTree(t *testing.T) {
 | *17 |             +- Filter Scan <Row> (seekable_key_size: 0)                                   |
 |  18 |                +- Index Scan on SongsBySongGenre <Row> (Full scan, scan_method: Row)      |
 +-----+-------------------------------------------------------------------------------------------+
+
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
@@ -140,6 +141,7 @@ Predicates(identified by ID):
 | *17 |     +Filter Scan<Row>(seekable_key_size:0)                                  |
 |  18 |      +Index Scan on SongsBySongGenre<Row>(Full scan,scan_method:Row)        |
 +-----+-----------------------------------------------------------------------------+
+
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
@@ -172,6 +174,7 @@ Predicates(identified by ID):
 |  18 |      +Index Scan on SongsBySongGenre<Row |
 |     |       >(Full scan,scan_method:Row)       |
 +-----+------------------------------------------+
+
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
@@ -205,6 +208,7 @@ Predicates(identified by ID):
 |     |                   Row> (Full scan, scan_method: Ro |
 |     |                   w)                               |
 +-----+----------------------------------------------------+
+
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
@@ -231,6 +235,7 @@ Predicates(identified by ID):
 | *17 |             +- Filter Scan <Row> (seekable_key_size: 0)                                   |      |       |         |
 |  18 |                +- Index Scan on SongsBySongGenre <Row> (Full scan, scan_method: Row)      |   33 |     7 | 0.84 ms |
 +-----+-------------------------------------------------------------------------------------------+------+-------+---------+
+
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
@@ -274,6 +279,7 @@ Predicates(identified by ID):
 | *17 |             +- Filter Scan <Row> (seekable_key_size: 0)                                   |      |         |          |
 |  18 |                +- Index Scan on SongsBySongGenre <Row> (Full scan, scan_method: Row)      |   33 |      63 |       30 |
 +-----+-------------------------------------------------------------------------------------------+------+---------+----------+
+
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
@@ -306,6 +312,7 @@ Predicates(identified by ID):
 | *17 |             +- Filter Scan <Row> (seekable_key_size: 0)                                   |      |         |          |
 |  18 |                +- Index Scan on SongsBySongGenre <Row> (Full scan, scan_method: Row)      |   33 |      63 |       30 |
 +-----+-------------------------------------------------------------------------------------------+------+---------+----------+
+
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
@@ -345,6 +352,7 @@ Predicates(identified by ID):
 |     |                    scan, scan_method: Row, Scanned=63, Filte |      |
 |     |                   red=30)                                    |      |
 +-----+--------------------------------------------------------------+------+
+
 Predicates(identified by ID):
   1: Split Range: ($AlbumId = $AlbumId_1)
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
@@ -463,8 +471,10 @@ func TestPrintResult_PrintSections(t *testing.T) {
 	want := heredoc.Doc(`
 Predicates(identified by ID):
  2: Condition: ($SingerId = $SingerId_1)
+
 Ordering(identified by ID):
  0: Key: $SongGenre
+
 Aggregates(identified by ID):
  1: Key: $SingerId
     Agg: COUNT(*)
@@ -483,12 +493,44 @@ Aggregates(identified by ID):
 	want = heredoc.Doc(`
 Ordering(identified by ID):
  0: Key: $sort_key=$SongGenre
+
 Aggregates(identified by ID):
  1: Key: $group_key=$SingerId
     Agg: $song_count=COUNT(*)
 `)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("printResult(show vars) mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrintResult_AppendixWrapWidth(t *testing.T) {
+	rows := []plantree.RowWithPredicates{
+		{
+			ID:          0,
+			DisplayName: "Sort",
+			NodeText:    "Sort",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Type: "Key", Description: "AlphaColumn"},
+				{Type: "Key", Description: "BetaColumn"},
+				{Type: "Key", Description: "GammaColumn"},
+			},
+		},
+	}
+
+	got, err := printResult(rows, printResultOptions{
+		printSections:     PrintSections{PrintOrdering},
+		appendixWrapWidth: 30,
+	})
+	if err != nil {
+		t.Fatalf("printResult() error = %v", err)
+	}
+	want := heredoc.Doc(`
+Ordering(identified by ID):
+ 0: Key: AlphaColumn,
+    BetaColumn, GammaColumn
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -545,6 +587,7 @@ func TestPrintResult_ResolveScalarVars(t *testing.T) {
 	want := heredoc.Doc(`
 Ordering(identified by ID):
  0: Key: COUNT_FINAL($v1) DESC, $group_SongGenre, $SongGenre + $SingerId
+
 Aggregates(identified by ID):
  1: Key: $SongGenre
     Agg: COUNT_FINAL($v1)
@@ -566,6 +609,7 @@ Aggregates(identified by ID):
 	want = heredoc.Doc(`
 Ordering(identified by ID):
  0: Key: $sort_count=COUNT_FINAL($v1) DESC, $sort_genre=$group_SongGenre, $sort_expression=$SongGenre + $SingerId
+
 Aggregates(identified by ID):
  1: Key: $group_SongGenre'=$SongGenre
     Agg: $SongCount=COUNT_FINAL($v1)
@@ -586,6 +630,7 @@ Aggregates(identified by ID):
 	want = heredoc.Doc(`
 Ordering(identified by ID):
  0: Key: COUNT_FINAL(COUNT()) DESC, SongGenre, SongGenre + SingerId
+
 Aggregates(identified by ID):
  1: Key: SongGenre
     Agg: COUNT_FINAL($v1)

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -404,7 +404,7 @@ Predicates(identified by ID):
 
 			opts = append(opts, tcase.opts...)
 
-			got, err := renderTreeImpl(stats.GetQueryPlan().GetPlanNodes(), tcase.renderDef, PrintSections{PrintPredicates}, false, false, true, tcase.inline, opts)
+			got, err := renderTreeImpl(stats.GetQueryPlan().GetPlanNodes(), tcase.renderDef, PrintSections{PrintPredicates}, false, false, false, true, tcase.inline, opts)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -448,7 +448,7 @@ func TestPrintResult_PrintSections(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintPredicates, PrintOrdering, PrintAggregate}, false, false)
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintPredicates, PrintOrdering, PrintAggregate}, false, false, false)
 	if err != nil {
 		t.Fatalf("printResult() error = %v", err)
 	}
@@ -465,7 +465,7 @@ Aggregates(identified by ID):
 		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, true, false)
+	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, true, false, false)
 	if err != nil {
 		t.Fatalf("printResult(show vars) error = %v", err)
 	}
@@ -524,15 +524,15 @@ func TestPrintResult_ResolveScalarVars(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, false, true)
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, false, true, false)
 	if err != nil {
 		t.Fatalf("printResult() error = %v", err)
 	}
 	want := heredoc.Doc(`
 Ordering(identified by ID):
- 0: Key: COUNT_FINAL($v1) DESC, SongGenre, SongGenre + SingerId
+ 0: Key: COUNT_FINAL($v1) DESC, $group_SongGenre, $SongGenre + $SingerId
 Aggregates(identified by ID):
- 1: Key: SongGenre
+ 1: Key: $SongGenre
     Agg: COUNT_FINAL($v1)
  2: Key: SongGenre
     Agg: COUNT()
@@ -541,21 +541,38 @@ Aggregates(identified by ID):
 		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
 	}
 
-	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, true, true)
+	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, true, true, false)
 	if err != nil {
 		t.Fatalf("printResult(show vars and resolve vars) error = %v", err)
 	}
 	want = heredoc.Doc(`
 Ordering(identified by ID):
- 0: Key: $sort_count=COUNT_FINAL($v1) DESC, $sort_genre=SongGenre, $sort_expression=SongGenre + SingerId
+ 0: Key: $sort_count=COUNT_FINAL($v1) DESC, $sort_genre=$group_SongGenre, $sort_expression=$SongGenre + $SingerId
 Aggregates(identified by ID):
- 1: Key: $group_SongGenre'=SongGenre
+ 1: Key: $group_SongGenre'=$SongGenre
     Agg: $SongCount=COUNT_FINAL($v1)
  2: Key: $group_SongGenre=SongGenre
     Agg: $v1=COUNT()
 `)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("printResult(show vars and resolve vars) mismatch (-want +got):\n%s", diff)
+	}
+
+	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, false, false, true)
+	if err != nil {
+		t.Fatalf("printResult(resolve vars recursively) error = %v", err)
+	}
+	want = heredoc.Doc(`
+Ordering(identified by ID):
+ 0: Key: COUNT_FINAL(COUNT()) DESC, SongGenre, SongGenre + SingerId
+Aggregates(identified by ID):
+ 1: Key: SongGenre
+    Agg: COUNT_FINAL($v1)
+ 2: Key: SongGenre
+    Agg: COUNT()
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("printResult(resolve vars recursively) mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -572,7 +589,7 @@ func TestPrintResult_RawPrintSections(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintTyped}, false, false)
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintTyped}, false, false, false)
 	if err != nil {
 		t.Fatalf("printResult(typed) error = %v", err)
 	}
@@ -584,7 +601,7 @@ Node Parameters(identified by ID):
 		t.Fatalf("printResult(typed) mismatch (-want +got):\n%s", diff)
 	}
 
-	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintFull}, false, false)
+	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintFull}, false, false, false)
 	if err != nil {
 		t.Fatalf("printResult(full) error = %v", err)
 	}
@@ -599,7 +616,7 @@ Node Parameters(identified by ID):
 }
 
 func TestPrintResult_UnsupportedPrintSection(t *testing.T) {
-	_, err := printResult(tableRenderDef{}, nil, PrintSections{"broken"}, false, false)
+	_, err := printResult(tableRenderDef{}, nil, PrintSections{"broken"}, false, false, false)
 	if err == nil {
 		t.Fatal("printResult() error = nil, want non-nil")
 	}

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -594,6 +594,16 @@ Node Parameters(identified by ID):
 	}
 }
 
+func TestPrintResult_UnsupportedPrintSection(t *testing.T) {
+	_, err := printResult(tableRenderDef{}, nil, PrintSections{"broken"}, false, false)
+	if err == nil {
+		t.Fatal("printResult() error = nil, want non-nil")
+	}
+	if got, want := err.Error(), "unsupported print section: broken"; got != want {
+		t.Fatalf("printResult() error = %q, want %q", got, want)
+	}
+}
+
 func TestParsePrintSections(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -437,7 +437,7 @@ func TestPrintResult_PrintSections(t *testing.T) {
 			DisplayName: "Sort",
 			NodeText:    "Sort",
 			ScalarChildLinks: []plantree.ScalarChildLink{
-				{Type: "Key", Variable: "sort_key", Description: "$SongGenre"},
+				{Type: "Key", Variable: "sort_key", Description: "$SongGenre (DESC)"},
 				{Type: "Value", Variable: "sort_value", Description: "$SongName"},
 			},
 		},
@@ -473,7 +473,7 @@ Predicates(identified by ID):
  2: Condition: ($SingerId = $SingerId_1)
 
 Ordering(identified by ID):
- 0: Key: $SongGenre
+ 0: Key: $SongGenre DESC
 
 Aggregates(identified by ID):
  1: Key: $SingerId
@@ -492,7 +492,7 @@ Aggregates(identified by ID):
 	}
 	want = heredoc.Doc(`
 Ordering(identified by ID):
- 0: Key: $sort_key=$SongGenre
+ 0: Key: $sort_key=$SongGenre DESC
 
 Aggregates(identified by ID):
  1: Key: $group_key=$SingerId

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -490,6 +490,7 @@ func TestPrintResult_ResolveScalarVars(t *testing.T) {
 			ScalarChildLinks: []plantree.ScalarChildLink{
 				{Type: "Key", Variable: "sort_count", Description: "$SongCount (DESC)"},
 				{Type: "Key", Variable: "sort_genre", Description: "$group_SongGenre'"},
+				{Type: "Key", Variable: "sort_expression", Description: "$left + $right"},
 			},
 		},
 		{
@@ -516,6 +517,9 @@ func TestPrintResult_ResolveScalarVars(t *testing.T) {
 			NodeText:    "Scan",
 			ScalarChildLinks: []plantree.ScalarChildLink{
 				{Variable: "SongGenre", Description: "SongGenre"},
+				{Variable: "SingerId", Description: "SingerId"},
+				{Variable: "left", Description: "$SongGenre"},
+				{Variable: "right", Description: "$SingerId"},
 			},
 		},
 	}
@@ -526,7 +530,7 @@ func TestPrintResult_ResolveScalarVars(t *testing.T) {
 	}
 	want := heredoc.Doc(`
 Ordering(identified by ID):
- 0: Key: COUNT_FINAL($v1) DESC, SongGenre
+ 0: Key: COUNT_FINAL($v1) DESC, SongGenre, SongGenre + SingerId
 Aggregates(identified by ID):
  1: Key: SongGenre
     Agg: COUNT_FINAL($v1)
@@ -543,7 +547,7 @@ Aggregates(identified by ID):
 	}
 	want = heredoc.Doc(`
 Ordering(identified by ID):
- 0: Key: $sort_count=COUNT_FINAL($v1) DESC, $sort_genre=SongGenre
+ 0: Key: $sort_count=COUNT_FINAL($v1) DESC, $sort_genre=SongGenre, $sort_expression=SongGenre + SingerId
 Aggregates(identified by ID):
  1: Key: $group_SongGenre'=SongGenre
     Agg: $SongCount=COUNT_FINAL($v1)

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -404,7 +404,7 @@ Predicates(identified by ID):
 
 			opts = append(opts, tcase.opts...)
 
-			got, err := renderTreeImpl(stats.GetQueryPlan().GetPlanNodes(), tcase.renderDef, PrintSections{PrintPredicates}, false, true, tcase.inline, opts)
+			got, err := renderTreeImpl(stats.GetQueryPlan().GetPlanNodes(), tcase.renderDef, PrintSections{PrintPredicates}, false, false, true, tcase.inline, opts)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -448,7 +448,7 @@ func TestPrintResult_PrintSections(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintPredicates, PrintOrdering, PrintAggregate}, false)
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintPredicates, PrintOrdering, PrintAggregate}, false, false)
 	if err != nil {
 		t.Fatalf("printResult() error = %v", err)
 	}
@@ -463,6 +463,21 @@ Aggregates(identified by ID):
 `)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
+	}
+
+	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, true, false)
+	if err != nil {
+		t.Fatalf("printResult(show vars) error = %v", err)
+	}
+	want = heredoc.Doc(`
+Ordering(identified by ID):
+ 0: Key: $sort_key=$SongGenre
+Aggregates(identified by ID):
+ 1: Key: $group_key=$SingerId
+    Agg: $song_count=COUNT(*)
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("printResult(show vars) mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -505,7 +520,7 @@ func TestPrintResult_ResolveScalarVars(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, true)
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, false, true)
 	if err != nil {
 		t.Fatalf("printResult() error = %v", err)
 	}
@@ -520,6 +535,23 @@ Aggregates(identified by ID):
 `)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
+	}
+
+	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, true, true)
+	if err != nil {
+		t.Fatalf("printResult(show vars and resolve vars) error = %v", err)
+	}
+	want = heredoc.Doc(`
+Ordering(identified by ID):
+ 0: Key: $sort_count=COUNT_FINAL($v1) DESC, $sort_genre=SongGenre
+Aggregates(identified by ID):
+ 1: Key: $group_SongGenre'=SongGenre
+    Agg: $SongCount=COUNT_FINAL($v1)
+ 2: Key: $group_SongGenre=SongGenre
+    Agg: $v1=COUNT()
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("printResult(show vars and resolve vars) mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -536,7 +568,7 @@ func TestPrintResult_RawPrintSections(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintTyped}, false)
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintTyped}, false, false)
 	if err != nil {
 		t.Fatalf("printResult(typed) error = %v", err)
 	}
@@ -548,7 +580,7 @@ Node Parameters(identified by ID):
 		t.Fatalf("printResult(typed) mismatch (-want +got):\n%s", diff)
 	}
 
-	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintFull}, false)
+	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintFull}, false, false)
 	if err != nil {
 		t.Fatalf("printResult(full) error = %v", err)
 	}

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -503,37 +503,6 @@ Aggregates(identified by ID):
 	}
 }
 
-func TestPrintResult_AppendixWrapWidth(t *testing.T) {
-	rows := []plantree.RowWithPredicates{
-		{
-			ID:          0,
-			DisplayName: "Sort",
-			NodeText:    "Sort",
-			ScalarChildLinks: []plantree.ScalarChildLink{
-				{Type: "Key", Description: "AlphaColumn"},
-				{Type: "Key", Description: "BetaColumn"},
-				{Type: "Key", Description: "GammaColumn"},
-			},
-		},
-	}
-
-	got, err := printResult(rows, printResultOptions{
-		printSections:     PrintSections{PrintOrdering},
-		appendixWrapWidth: 30,
-	})
-	if err != nil {
-		t.Fatalf("printResult() error = %v", err)
-	}
-	want := heredoc.Doc(`
-Ordering(identified by ID):
- 0: Key: AlphaColumn,
-    BetaColumn, GammaColumn
-`)
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
-	}
-}
-
 func TestPrintResult_ResolveScalarVars(t *testing.T) {
 	rows := []plantree.RowWithPredicates{
 		{

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -404,13 +404,163 @@ Predicates(identified by ID):
 
 			opts = append(opts, tcase.opts...)
 
-			got, err := renderTreeImpl(stats.GetQueryPlan().GetPlanNodes(), tcase.renderDef, PrintPredicates, true, tcase.inline, opts)
+			got, err := renderTreeImpl(stats.GetQueryPlan().GetPlanNodes(), tcase.renderDef, PrintSections{PrintPredicates}, true, tcase.inline, opts)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			if diff := cmp.Diff(tcase.want, got); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPrintResult_PrintSections(t *testing.T) {
+	rows := []plantree.RowWithPredicates{
+		{
+			ID:          0,
+			DisplayName: "Sort",
+			NodeText:    "Sort",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Type: "Key", Variable: "sort_key", Description: "$SongGenre"},
+				{Type: "Value", Variable: "sort_value", Description: "$SongName"},
+			},
+		},
+		{
+			ID:          1,
+			DisplayName: "Aggregate",
+			NodeText:    "Aggregate",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Type: "Key", Variable: "group_key", Description: "$SingerId"},
+				{Type: "Agg", Variable: "song_count", Description: "COUNT(*)"},
+			},
+		},
+		{
+			ID:          2,
+			DisplayName: "Hash Join",
+			NodeText:    "Hash Join",
+			Predicates:  []string{"Condition: ($SingerId = $SingerId_1)"},
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Type: "Condition", Description: "($SingerId = $SingerId_1)"},
+				{Type: "Build", Variable: "build_key", Description: "$SingerId_1"},
+			},
+		},
+	}
+
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintPredicates, PrintOrdering, PrintAggregate})
+	if err != nil {
+		t.Fatalf("printResult() error = %v", err)
+	}
+	want := heredoc.Doc(`
+Predicates(identified by ID):
+ 2: Condition: ($SingerId = $SingerId_1)
+Ordering(identified by ID):
+ 0: Key: $sort_key=$SongGenre
+Aggregates(identified by ID):
+ 1: Key: $group_key=$SingerId
+    Agg: $song_count=COUNT(*)
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrintResult_RawPrintSections(t *testing.T) {
+	rows := []plantree.RowWithPredicates{
+		{
+			ID:          0,
+			DisplayName: "Compute",
+			NodeText:    "Compute",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Variable: "value", Description: "$SingerId"},
+				{Type: "Agg", Variable: "song_count", Description: "COUNT(*)"},
+			},
+		},
+	}
+
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintTyped})
+	if err != nil {
+		t.Fatalf("printResult(typed) error = %v", err)
+	}
+	want := heredoc.Doc(`
+Node Parameters(identified by ID):
+ 0: Agg: $song_count=COUNT(*)
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("printResult(typed) mismatch (-want +got):\n%s", diff)
+	}
+
+	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintFull})
+	if err != nil {
+		t.Fatalf("printResult(full) error = %v", err)
+	}
+	want = heredoc.Doc(`
+Node Parameters(identified by ID):
+ 0: $value=$SingerId
+    Agg: $song_count=COUNT(*)
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("printResult(full) mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestParsePrintSections(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    PrintSections
+		wantErr string
+	}{
+		{
+			name:  "single section",
+			input: "predicates",
+			want:  PrintSections{PrintPredicates},
+		},
+		{
+			name:  "multiple sections",
+			input: "predicates,ordering,aggregate",
+			want:  PrintSections{PrintPredicates, PrintOrdering, PrintAggregate},
+		},
+		{
+			name:  "case and space",
+			input: " Predicates, Ordering ",
+			want:  PrintSections{PrintPredicates, PrintOrdering},
+		},
+		{
+			name:    "unknown",
+			input:   "broken",
+			wantErr: "unknown print section: broken",
+		},
+		{
+			name:    "duplicate",
+			input:   "predicates,predicates",
+			wantErr: "duplicate print section: predicates",
+		},
+		{
+			name:    "raw dump cannot be combined",
+			input:   "predicates,full",
+			wantErr: `print section "full" cannot be combined with other sections`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePrintSections(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("parsePrintSections() error = nil, want non-nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("parsePrintSections() error = %q, want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePrintSections() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("parsePrintSections() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -500,7 +650,7 @@ func TestRun_UsageErrors(t *testing.T) {
 		{
 			name:        "invalid print",
 			args:        []string{"-print", "broken"},
-			wantErrText: "unknown PrintMode: broken",
+			wantErrText: "unknown print section: broken",
 			postCheck: func(t *testing.T, stderr string, err error) {
 				t.Helper()
 				if !strings.Contains(stderr, "Invalid value for -print flag:") {

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -404,7 +404,7 @@ Predicates(identified by ID):
 
 			opts = append(opts, tcase.opts...)
 
-			got, err := renderTreeImpl(stats.GetQueryPlan().GetPlanNodes(), tcase.renderDef, PrintSections{PrintPredicates}, true, tcase.inline, opts)
+			got, err := renderTreeImpl(stats.GetQueryPlan().GetPlanNodes(), tcase.renderDef, PrintSections{PrintPredicates}, false, true, tcase.inline, opts)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -448,7 +448,7 @@ func TestPrintResult_PrintSections(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintPredicates, PrintOrdering, PrintAggregate})
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintPredicates, PrintOrdering, PrintAggregate}, false)
 	if err != nil {
 		t.Fatalf("printResult() error = %v", err)
 	}
@@ -456,10 +456,67 @@ func TestPrintResult_PrintSections(t *testing.T) {
 Predicates(identified by ID):
  2: Condition: ($SingerId = $SingerId_1)
 Ordering(identified by ID):
- 0: Key: $sort_key=$SongGenre
+ 0: Key: $SongGenre
 Aggregates(identified by ID):
- 1: Key: $group_key=$SingerId
-    Agg: $song_count=COUNT(*)
+ 1: Key: $SingerId
+    Agg: COUNT(*)
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPrintResult_ResolveScalarVars(t *testing.T) {
+	rows := []plantree.RowWithPredicates{
+		{
+			ID:          0,
+			DisplayName: "Sort",
+			NodeText:    "Sort",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Type: "Key", Variable: "sort_count", Description: "$SongCount (DESC)"},
+				{Type: "Key", Variable: "sort_genre", Description: "$group_SongGenre'"},
+			},
+		},
+		{
+			ID:          1,
+			DisplayName: "Aggregate",
+			NodeText:    "Aggregate",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Type: "Key", Variable: "group_SongGenre'", Description: "$group_SongGenre"},
+				{Type: "Agg", Variable: "SongCount", Description: "COUNT_FINAL($v1)"},
+			},
+		},
+		{
+			ID:          2,
+			DisplayName: "Aggregate",
+			NodeText:    "Aggregate",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Type: "Key", Variable: "group_SongGenre", Description: "$SongGenre"},
+				{Type: "Agg", Variable: "v1", Description: "COUNT()"},
+			},
+		},
+		{
+			ID:          3,
+			DisplayName: "Scan",
+			NodeText:    "Scan",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Variable: "SongGenre", Description: "SongGenre"},
+			},
+		},
+	}
+
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintOrdering, PrintAggregate}, true)
+	if err != nil {
+		t.Fatalf("printResult() error = %v", err)
+	}
+	want := heredoc.Doc(`
+Ordering(identified by ID):
+ 0: Key: COUNT_FINAL($v1) DESC, SongGenre
+Aggregates(identified by ID):
+ 1: Key: SongGenre
+    Agg: COUNT_FINAL($v1)
+ 2: Key: SongGenre
+    Agg: COUNT()
 `)
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("printResult() mismatch (-want +got):\n%s", diff)
@@ -479,7 +536,7 @@ func TestPrintResult_RawPrintSections(t *testing.T) {
 		},
 	}
 
-	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintTyped})
+	got, err := printResult(tableRenderDef{}, rows, PrintSections{PrintTyped}, false)
 	if err != nil {
 		t.Fatalf("printResult(typed) error = %v", err)
 	}
@@ -491,7 +548,7 @@ Node Parameters(identified by ID):
 		t.Fatalf("printResult(typed) mismatch (-want +got):\n%s", diff)
 	}
 
-	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintFull})
+	got, err = printResult(tableRenderDef{}, rows, PrintSections{PrintFull}, false)
 	if err != nil {
 		t.Fatalf("printResult(full) error = %v", err)
 	}

--- a/examples/pgexplainjson/main.go
+++ b/examples/pgexplainjson/main.go
@@ -201,7 +201,7 @@ func renderPlan(rootPlan *planNode, opts renderOptions) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	predicatePart, err := asciitable.RenderPredicates(rows, predicateSpec())
+	predicatePart, err := asciitable.RenderAppendix(rows, predicateAppendixSpec())
 	if err != nil {
 		return "", err
 	}
@@ -356,12 +356,13 @@ func tableSpec() asciitable.TableSpec[renderedRow] {
 	}
 }
 
-func predicateSpec() asciitable.PredicateSpec[renderedRow] {
-	return asciitable.PredicateSpec[renderedRow]{
+func predicateAppendixSpec() asciitable.AppendixSpec[renderedRow] {
+	return asciitable.AppendixSpec[renderedRow]{
+		Title: "Predicates(identified by ID):",
 		ID: func(row renderedRow) uint {
 			return row.id
 		},
-		Predicates: func(row renderedRow) []string {
+		Items: func(row renderedRow) []string {
 			return row.predicates
 		},
 	}

--- a/plantree/doc.go
+++ b/plantree/doc.go
@@ -15,14 +15,15 @@ which combines tree prefix and node title.
 The TreePart field remains exported for struct literals and cmp.Diff in tests; new code
 should use the accessors above when not constructing rows by hand.
 
-Rows also expose scalar child links in original plan order via
+Rows also expose scalar child links in original PlanNode.ChildLinks order via
 [RowWithPredicates.ScalarChildLinks]. Callers should group those links at
 rendering time using the parent row's [RowWithPredicates.DisplayName] together
 with each [ScalarChildLink.Type], because the same child-link type can have
 different meanings under different operators.
 [RowWithPredicates.ChildLinks] remains available for compatibility with older
 callers, but new code should prefer [RowWithPredicates.ScalarChildLinks] because
-it preserves Spanner's original child-link order.
+it preserves Spanner's original PlanNode.ChildLinks order after filtering to
+scalar child links.
 [RowWithPredicates.Keys] is also kept for compatibility and contains scalar
 child descriptions grouped by child-link type; new code should use
 [RowWithPredicates.ScalarChildLinks] when it needs variables, child indexes, or

--- a/plantree/doc.go
+++ b/plantree/doc.go
@@ -15,6 +15,12 @@ which combines tree prefix and node title.
 The TreePart field remains exported for struct literals and cmp.Diff in tests; new code
 should use the accessors above when not constructing rows by hand.
 
+Rows also expose scalar child links in original plan order via
+[RowWithPredicates.ScalarChildLinks]. Callers should group those links at
+rendering time using the parent row's [RowWithPredicates.DisplayName] together
+with each [ScalarChildLink.Type], because the same child-link type can have
+different meanings under different operators.
+
 A []string field would avoid one strings.Join in the renderer and one strings.Split in
 Text, but it is a breaking API change for modules that build [RowWithPredicates] literals
 in tests (for example github.com/apstndb/spanner-mycli). Downstream production code reviewed

--- a/plantree/doc.go
+++ b/plantree/doc.go
@@ -14,6 +14,8 @@ which combines tree prefix and node title.
 
 The TreePart field remains exported for struct literals and cmp.Diff in tests; new code
 should use the accessors above when not constructing rows by hand.
+When tests do construct [RowWithPredicates] values directly, prefer keyed
+composite literals so future exported fields do not break the call site.
 
 Rows also expose scalar child links in original PlanNode.ChildLinks order via
 [RowWithPredicates.ScalarChildLinks]. Callers should group those links at

--- a/plantree/doc.go
+++ b/plantree/doc.go
@@ -23,6 +23,10 @@ different meanings under different operators.
 [RowWithPredicates.ChildLinks] remains available for compatibility with older
 callers, but new code should prefer [RowWithPredicates.ScalarChildLinks] because
 it preserves Spanner's original child-link order.
+[RowWithPredicates.Keys] is also kept for compatibility and contains scalar
+child descriptions grouped by child-link type; new code should use
+[RowWithPredicates.ScalarChildLinks] when it needs variables, child indexes, or
+stable ordering.
 
 A []string field would avoid one strings.Join in the renderer and one strings.Split in
 Text, but it is a breaking API change for modules that build [RowWithPredicates] literals

--- a/plantree/doc.go
+++ b/plantree/doc.go
@@ -20,6 +20,9 @@ Rows also expose scalar child links in original plan order via
 rendering time using the parent row's [RowWithPredicates.DisplayName] together
 with each [ScalarChildLink.Type], because the same child-link type can have
 different meanings under different operators.
+[RowWithPredicates.ChildLinks] remains available for compatibility with older
+callers, but new code should prefer [RowWithPredicates.ScalarChildLinks] because
+it preserves Spanner's original child-link order.
 
 A []string field would avoid one strings.Join in the renderer and one strings.Split in
 Text, but it is a breaking API change for modules that build [RowWithPredicates] literals

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -33,23 +33,43 @@ type RowWithPredicates struct {
 	TreePart string
 	// NodeText is the rendered operator title, possibly split across visual lines.
 	NodeText string
+	// DisplayName is the raw Spanner PlanNode display name, before metadata is folded into NodeText.
+	DisplayName string
 	// Predicates contains filter predicate text associated with this row.
 	Predicates []string
-	// Keys contains key metadata associated with this row.
-	Keys map[string][]string
 	// ExecutionStats contains execution statistics associated with this row.
 	ExecutionStats stats.ExecutionStats
-	// ChildLinks contains resolved child-link metadata associated with this row.
-	ChildLinks map[string][]*spannerplan.ResolvedChildLink
+	// ScalarChildLinks contains this row's scalar child links in original ChildLinks order.
+	ScalarChildLinks []ScalarChildLink
+}
+
+// ScalarChildLink is a scalar child link attached to a rendered plan row.
+//
+// It keeps raw-ish child-link fields so callers can group links by the parent
+// row's DisplayName and the child-link Type. The same Type can have different
+// semantics under different parent operators, for example Sort Key versus
+// Aggregate Key.
+type ScalarChildLink struct {
+	// Type is the ChildLink type, such as "Condition", "Key", or "Agg".
+	Type string
+	// Variable is the ChildLink variable, when Spanner provides one.
+	Variable string
+	// Description is the scalar child node's short representation description.
+	Description string
+	// DisplayName is the scalar child node's raw PlanNode display name.
+	DisplayName string
+	// ChildIndex is the scalar child node's PlanNode index.
+	ChildIndex int32
 }
 
 type renderedNode struct {
 	ID                 int32
 	ContinuationAnchor string
 	NodeText           string
+	DisplayName        string
 	Predicates         []string
 	ExecutionStats     stats.ExecutionStats
-	ChildLinks         map[string][]*spannerplan.ResolvedChildLink
+	ScalarChildLinks   []ScalarChildLink
 	Children           []*renderedNode
 }
 
@@ -223,12 +243,13 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 			return nil, fmt.Errorf("unexpected rendered row line count for node %d: tree=%d node=%d", node.ID, wantTreeLines, gotLines)
 		}
 		result = append(result, RowWithPredicates{
-			ID:             node.ID,
-			Predicates:     node.Predicates,
-			ChildLinks:     node.ChildLinks,
-			TreePart:       row.TreePart,
-			NodeText:       row.NodeText,
-			ExecutionStats: node.ExecutionStats,
+			ID:               node.ID,
+			DisplayName:      node.DisplayName,
+			Predicates:       node.Predicates,
+			ScalarChildLinks: node.ScalarChildLinks,
+			TreePart:         row.TreePart,
+			NodeText:         row.NodeText,
+			ExecutionStats:   node.ExecutionStats,
 		})
 	}
 
@@ -274,8 +295,14 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 		return item.Child.GetKind() == sppb.PlanNode_SCALAR
 	})
 
-	childLinks := lo.GroupBy(scalarChildLinks, func(item *spannerplan.ResolvedChildLink) string {
-		return item.ChildLink.GetType()
+	renderedScalarChildLinks := lo.Map(scalarChildLinks, func(item *spannerplan.ResolvedChildLink, _ int) ScalarChildLink {
+		return ScalarChildLink{
+			Type:        item.ChildLink.GetType(),
+			Variable:    item.ChildLink.GetVariable(),
+			Description: item.Child.GetShortRepresentation().GetDescription(),
+			DisplayName: item.Child.GetDisplayName(),
+			ChildIndex:  item.Child.GetIndex(),
+		}
 	})
 
 	executionStats, err := stats.Extract(node, opts.disallowUnknownStats)
@@ -288,9 +315,10 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 		ID:                 node.GetIndex(),
 		ContinuationAnchor: continuationAnchor,
 		NodeText:           nodeText,
+		DisplayName:        node.GetDisplayName(),
 		Predicates:         predicates,
 		ExecutionStats:     *executionStats,
-		ChildLinks:         childLinks,
+		ScalarChildLinks:   renderedScalarChildLinks,
 	}
 
 	for _, child := range visibleChildLinks {

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -37,10 +37,9 @@ type RowWithPredicates struct {
 	DisplayName string
 	// Predicates contains filter predicate text associated with this row.
 	Predicates []string
-	// Keys contains key metadata associated with this row.
+	// Keys contains scalar child descriptions grouped by ChildLink type.
 	//
-	// Deprecated: this field is kept for source compatibility and contains scalar
-	// child descriptions grouped by ChildLink type.
+	// Deprecated: this field is kept for source compatibility.
 	// Use [RowWithPredicates.ScalarChildLinks] and filter by [ScalarChildLink.Type] instead.
 	Keys map[string][]string
 	// ExecutionStats contains execution statistics associated with this row.

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -49,7 +49,7 @@ type RowWithPredicates struct {
 	//
 	// Deprecated: use [RowWithPredicates.ScalarChildLinks] for ordered scalar child-link metadata.
 	ChildLinks map[string][]*spannerplan.ResolvedChildLink
-	// ScalarChildLinks contains this row's scalar child links in original ChildLinks order.
+	// ScalarChildLinks contains this row's scalar child links in original PlanNode.ChildLinks order.
 	ScalarChildLinks []ScalarChildLink
 }
 

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -37,8 +37,17 @@ type RowWithPredicates struct {
 	DisplayName string
 	// Predicates contains filter predicate text associated with this row.
 	Predicates []string
+	// Keys contains key metadata associated with this row.
+	//
+	// Deprecated: this field is kept for source compatibility and is not populated.
+	// Use [RowWithPredicates.ScalarChildLinks] and filter by [ScalarChildLink.Type] instead.
+	Keys map[string][]string
 	// ExecutionStats contains execution statistics associated with this row.
 	ExecutionStats stats.ExecutionStats
+	// ChildLinks contains resolved child-link metadata associated with this row.
+	//
+	// Deprecated: use [RowWithPredicates.ScalarChildLinks] for ordered scalar child-link metadata.
+	ChildLinks map[string][]*spannerplan.ResolvedChildLink
 	// ScalarChildLinks contains this row's scalar child links in original ChildLinks order.
 	ScalarChildLinks []ScalarChildLink
 }
@@ -69,6 +78,7 @@ type renderedNode struct {
 	DisplayName        string
 	Predicates         []string
 	ExecutionStats     stats.ExecutionStats
+	ChildLinks         map[string][]*spannerplan.ResolvedChildLink
 	ScalarChildLinks   []ScalarChildLink
 	Children           []*renderedNode
 }
@@ -246,6 +256,7 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 			ID:               node.ID,
 			DisplayName:      node.DisplayName,
 			Predicates:       node.Predicates,
+			ChildLinks:       node.ChildLinks,
 			ScalarChildLinks: node.ScalarChildLinks,
 			TreePart:         row.TreePart,
 			NodeText:         row.NodeText,
@@ -295,6 +306,10 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 		return item.Child.GetKind() == sppb.PlanNode_SCALAR
 	})
 
+	childLinks := lo.GroupBy(scalarChildLinks, func(item *spannerplan.ResolvedChildLink) string {
+		return item.ChildLink.GetType()
+	})
+
 	renderedScalarChildLinks := lo.Map(scalarChildLinks, func(item *spannerplan.ResolvedChildLink, _ int) ScalarChildLink {
 		return ScalarChildLink{
 			Type:        item.ChildLink.GetType(),
@@ -318,6 +333,7 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 		DisplayName:        node.GetDisplayName(),
 		Predicates:         predicates,
 		ExecutionStats:     *executionStats,
+		ChildLinks:         childLinks,
 		ScalarChildLinks:   renderedScalarChildLinks,
 	}
 

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -39,7 +39,8 @@ type RowWithPredicates struct {
 	Predicates []string
 	// Keys contains key metadata associated with this row.
 	//
-	// Deprecated: this field is kept for source compatibility and is not populated.
+	// Deprecated: this field is kept for source compatibility and contains scalar
+	// child descriptions grouped by ChildLink type.
 	// Use [RowWithPredicates.ScalarChildLinks] and filter by [ScalarChildLink.Type] instead.
 	Keys map[string][]string
 	// ExecutionStats contains execution statistics associated with this row.
@@ -77,6 +78,7 @@ type renderedNode struct {
 	NodeText           string
 	DisplayName        string
 	Predicates         []string
+	Keys               map[string][]string
 	ExecutionStats     stats.ExecutionStats
 	ChildLinks         map[string][]*spannerplan.ResolvedChildLink
 	ScalarChildLinks   []ScalarChildLink
@@ -256,6 +258,7 @@ func ProcessPlan(qp *spannerplan.QueryPlan, opts ...Option) (rows []RowWithPredi
 			ID:               node.ID,
 			DisplayName:      node.DisplayName,
 			Predicates:       node.Predicates,
+			Keys:             node.Keys,
 			ChildLinks:       node.ChildLinks,
 			ScalarChildLinks: node.ScalarChildLinks,
 			TreePart:         row.TreePart,
@@ -309,6 +312,11 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 	childLinks := lo.GroupBy(scalarChildLinks, func(item *spannerplan.ResolvedChildLink) string {
 		return item.ChildLink.GetType()
 	})
+	keys := lo.MapValues(childLinks, func(items []*spannerplan.ResolvedChildLink, _ string) []string {
+		return lo.Map(items, func(item *spannerplan.ResolvedChildLink, _ int) string {
+			return item.Child.GetShortRepresentation().GetDescription()
+		})
+	})
 
 	renderedScalarChildLinks := lo.Map(scalarChildLinks, func(item *spannerplan.ResolvedChildLink, _ int) ScalarChildLink {
 		return ScalarChildLink{
@@ -332,6 +340,7 @@ func buildRenderedTree(qp *spannerplan.QueryPlan, link *sppb.PlanNode_ChildLink,
 		NodeText:           nodeText,
 		DisplayName:        node.GetDisplayName(),
 		Predicates:         predicates,
+		Keys:               keys,
 		ExecutionStats:     *executionStats,
 		ChildLinks:         childLinks,
 		ScalarChildLinks:   renderedScalarChildLinks,

--- a/plantree/plantree_test.go
+++ b/plantree/plantree_test.go
@@ -426,6 +426,9 @@ func TestProcessPlan_ScalarChildLinksPreserveParentContextAndOrder(t *testing.T)
 	if diff := cmp.Diff(wantSortLinks, sortRow.ScalarChildLinks); diff != "" {
 		t.Fatalf("sort ScalarChildLinks mismatch (-want +got):\n%s", diff)
 	}
+	if got := sortRow.ChildLinks["Key"]; len(got) != 1 || got[0].ChildLink.GetVariable() != "sort_key" {
+		t.Fatalf("sort deprecated ChildLinks[Key] = %v, want sort_key", got)
+	}
 
 	aggregateRow := rowByID(t, rows, 3)
 	wantAggregateLinks := []ScalarChildLink{
@@ -434,6 +437,9 @@ func TestProcessPlan_ScalarChildLinksPreserveParentContextAndOrder(t *testing.T)
 	}
 	if diff := cmp.Diff(wantAggregateLinks, aggregateRow.ScalarChildLinks); diff != "" {
 		t.Fatalf("aggregate ScalarChildLinks mismatch (-want +got):\n%s", diff)
+	}
+	if got := aggregateRow.ChildLinks["Agg"]; len(got) != 1 || got[0].ChildLink.GetVariable() != "song_count" {
+		t.Fatalf("aggregate deprecated ChildLinks[Agg] = %v, want song_count", got)
 	}
 }
 

--- a/plantree/plantree_test.go
+++ b/plantree/plantree_test.go
@@ -352,6 +352,91 @@ func TestProcessPlan_FullTextSearchPredicates(t *testing.T) {
 	}
 }
 
+func TestProcessPlan_ScalarChildLinksPreserveParentContextAndOrder(t *testing.T) {
+	qp, err := spannerplan.New([]*sppb.PlanNode{
+		{
+			Index:       0,
+			DisplayName: "Sort",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 1, Type: "Key", Variable: "sort_key"},
+				{ChildIndex: 2, Type: "Value", Variable: "sort_value"},
+				{ChildIndex: 3},
+			},
+		},
+		{
+			Index:       1,
+			DisplayName: "Reference",
+			Kind:        sppb.PlanNode_SCALAR,
+			ShortRepresentation: &sppb.PlanNode_ShortRepresentation{
+				Description: "$SongGenre",
+			},
+		},
+		{
+			Index:       2,
+			DisplayName: "Reference",
+			Kind:        sppb.PlanNode_SCALAR,
+			ShortRepresentation: &sppb.PlanNode_ShortRepresentation{
+				Description: "$SongName",
+			},
+		},
+		{
+			Index:       3,
+			DisplayName: "Aggregate",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 4, Type: "Key", Variable: "group_key"},
+				{ChildIndex: 5, Type: "Agg", Variable: "song_count"},
+			},
+		},
+		{
+			Index:       4,
+			DisplayName: "Reference",
+			Kind:        sppb.PlanNode_SCALAR,
+			ShortRepresentation: &sppb.PlanNode_ShortRepresentation{
+				Description: "$SingerId",
+			},
+		},
+		{
+			Index:       5,
+			DisplayName: "Function",
+			Kind:        sppb.PlanNode_SCALAR,
+			ShortRepresentation: &sppb.PlanNode_ShortRepresentation{
+				Description: "COUNT(*)",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	rows, err := ProcessPlan(qp)
+	if err != nil {
+		t.Fatalf("ProcessPlan() error = %v", err)
+	}
+
+	sortRow := rowByID(t, rows, 0)
+	if sortRow.DisplayName != "Sort" {
+		t.Fatalf("sort row DisplayName = %q, want Sort", sortRow.DisplayName)
+	}
+	wantSortLinks := []ScalarChildLink{
+		{Type: "Key", Variable: "sort_key", Description: "$SongGenre", DisplayName: "Reference", ChildIndex: 1},
+		{Type: "Value", Variable: "sort_value", Description: "$SongName", DisplayName: "Reference", ChildIndex: 2},
+	}
+	if diff := cmp.Diff(wantSortLinks, sortRow.ScalarChildLinks); diff != "" {
+		t.Fatalf("sort ScalarChildLinks mismatch (-want +got):\n%s", diff)
+	}
+
+	aggregateRow := rowByID(t, rows, 3)
+	wantAggregateLinks := []ScalarChildLink{
+		{Type: "Key", Variable: "group_key", Description: "$SingerId", DisplayName: "Reference", ChildIndex: 4},
+		{Type: "Agg", Variable: "song_count", Description: "COUNT(*)", DisplayName: "Function", ChildIndex: 5},
+	}
+	if diff := cmp.Diff(wantAggregateLinks, aggregateRow.ScalarChildLinks); diff != "" {
+		t.Fatalf("aggregate ScalarChildLinks mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func hangingIndentPlan(t *testing.T) *spannerplan.QueryPlan {
 	t.Helper()
 

--- a/plantree/plantree_test.go
+++ b/plantree/plantree_test.go
@@ -426,6 +426,13 @@ func TestProcessPlan_ScalarChildLinksPreserveParentContextAndOrder(t *testing.T)
 	if diff := cmp.Diff(wantSortLinks, sortRow.ScalarChildLinks); diff != "" {
 		t.Fatalf("sort ScalarChildLinks mismatch (-want +got):\n%s", diff)
 	}
+	wantSortKeys := map[string][]string{
+		"Key":   {"$SongGenre"},
+		"Value": {"$SongName"},
+	}
+	if diff := cmp.Diff(wantSortKeys, sortRow.Keys); diff != "" {
+		t.Fatalf("sort deprecated Keys mismatch (-want +got):\n%s", diff)
+	}
 	if got := sortRow.ChildLinks["Key"]; len(got) != 1 || got[0].ChildLink.GetVariable() != "sort_key" {
 		t.Fatalf("sort deprecated ChildLinks[Key] = %v, want sort_key", got)
 	}
@@ -437,6 +444,13 @@ func TestProcessPlan_ScalarChildLinksPreserveParentContextAndOrder(t *testing.T)
 	}
 	if diff := cmp.Diff(wantAggregateLinks, aggregateRow.ScalarChildLinks); diff != "" {
 		t.Fatalf("aggregate ScalarChildLinks mismatch (-want +got):\n%s", diff)
+	}
+	wantAggregateKeys := map[string][]string{
+		"Key": {"$SingerId"},
+		"Agg": {"COUNT(*)"},
+	}
+	if diff := cmp.Diff(wantAggregateKeys, aggregateRow.Keys); diff != "" {
+		t.Fatalf("aggregate deprecated Keys mismatch (-want +got):\n%s", diff)
 	}
 	if got := aggregateRow.ChildLinks["Agg"]; len(got) != 1 || got[0].ChildLink.GetVariable() != "song_count" {
 		t.Fatalf("aggregate deprecated ChildLinks[Agg] = %v, want song_count", got)

--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -166,7 +166,7 @@ func renderTreeTable(planNodes []*sppb.PlanNode, mode RenderMode, format Format,
 }
 
 func renderPredicatesPart(rendered []plantree.RowWithPredicates) (string, error) {
-	return asciitable.RenderPredicates(rendered, predicateSpec())
+	return asciitable.RenderAppendix(rendered, predicateAppendixSpec())
 }
 
 func renderTablePart(rendered []plantree.RowWithPredicates, withStats bool) (string, error) {
@@ -222,14 +222,15 @@ func spannerTableSpec(withStats bool) asciitable.TableSpec[plantree.RowWithPredi
 	return spec
 }
 
-func predicateSpec() asciitable.PredicateSpec[plantree.RowWithPredicates] {
-	return asciitable.PredicateSpec[plantree.RowWithPredicates]{
+func predicateAppendixSpec() asciitable.AppendixSpec[plantree.RowWithPredicates] {
+	return asciitable.AppendixSpec[plantree.RowWithPredicates]{
+		Title: "Predicates(identified by ID):",
 		ID: func(row plantree.RowWithPredicates) uint {
 			// Spanner PlanNode indexes are zero-based node positions, so they are
 			// non-negative when used as predicate appendix display IDs.
 			return uint(row.ID)
 		},
-		Predicates: func(row plantree.RowWithPredicates) []string {
+		Items: func(row plantree.RowWithPredicates) []string {
 			return row.Predicates
 		},
 	}


### PR DESCRIPTION
## Summary
- generalize appendix rendering beyond predicates with asciitable.RenderAppendix
- expose ordered scalar child links and parent display names from plantree
- add rendertree -print sections for predicates, ordering, aggregate, typed, and full
- remove unreleased predicate-specific asciitable compatibility API in favor of AppendixSpec/RenderAppendix

## Compatibility note
- Compared against the latest released tag v0.1.9. The asciitable package, PredicateSpec, and RenderPredicates were introduced only on this PR branch, so PredicateSpec and RenderPredicates were removed instead of kept as deprecated compatibility symbols.
- Released deprecated symbols from v0.1.9 are still retained. RowWithPredicates.Keys and RowWithPredicates.ChildLinks were already released fields in v0.1.9, so this PR keeps them populated as compatibility mirrors while documenting ScalarChildLinks as the preferred API.

## Verification
- go test ./...
- mise x -- golangci-lint run --timeout=5m
- git diff --check