### PR TITLE
refactor: share scalar appendix rendering

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -6,9 +6,11 @@ For performance feedback:
 
 - Do not suggest allocation micro-optimizations unless the code is on a demonstrated hot path, inside a performance-critical loop, or the change materially improves asymptotic behavior.
 - Avoid comments that only recommend preallocating small slices, hoisting immutable helper values to package scope, or reducing one-time allocations in CLI setup, parsing, and tests unless there is clear evidence that the cost matters.
+- Do not suggest replacing expressive standard-library helpers such as `strings.TrimPrefix` with manual slicing solely for performance. Prefer readability unless profiling or a hot path justifies the change.
 - Prefer one consolidated performance comment over multiple near-duplicate comments on the same theme.
 
 For this repository:
 
 - Focus on compatibility of rendered output, public API clarity, and robustness of plan parsing / rendering.
 - Treat command setup and one-shot CLI parsing paths as low priority for allocation tuning.
+- For JSON tags, treat `omitempty` as an API design choice. Check whether nil, empty, and omitted values intentionally have distinct semantics before recommending a tag change.

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/apstndb/spannerplan"
 	"github.com/apstndb/spannerplan/asciitable"
+	"github.com/apstndb/spannerplan/internal/scalarappendix"
 	"github.com/apstndb/spannerplan/plantree"
 	"github.com/apstndb/spannerplan/stats"
 )
@@ -176,11 +177,6 @@ var (
 
 var secsRe = regexp.MustCompile(`secs$`)
 
-var (
-	scalarVariableReferenceRe   = regexp.MustCompile(`\$[A-Za-z0-9_']+(?:\.[A-Za-z0-9_']+)*`)
-	scalarVariableDescriptionRe = regexp.MustCompile(`^\$[A-Za-z0-9_']+(?:\.[A-Za-z0-9_']+)*$`)
-)
-
 func secsToS(v any) string {
 	return secsRe.ReplaceAllString(fmt.Sprint(v), "s")
 }
@@ -264,47 +260,11 @@ const (
 type PrintSections []PrintSection
 
 func parsePrintSections(s string) (PrintSections, error) {
-	var sections PrintSections
-	seen := map[PrintSection]bool{}
-	for _, raw := range strings.Split(s, ",") {
-		part := strings.TrimSpace(strings.ToLower(raw))
-		if part == "" {
-			return nil, fmt.Errorf("print section must not be empty")
-		}
-
-		var section PrintSection
-		switch part {
-		case string(PrintPredicates):
-			section = PrintPredicates
-		case string(PrintOrdering):
-			section = PrintOrdering
-		case string(PrintAggregate):
-			section = PrintAggregate
-		case string(PrintTyped):
-			section = PrintTyped
-		case string(PrintFull):
-			section = PrintFull
-		default:
-			return nil, fmt.Errorf("unknown print section: %s", raw)
-		}
-
-		if seen[section] {
-			return nil, fmt.Errorf("duplicate print section: %s", section)
-		}
-		seen[section] = true
-		sections = append(sections, section)
+	sections, err := scalarappendix.ParseSections(s)
+	if err != nil {
+		return nil, err
 	}
-
-	if len(sections) == 0 {
-		return nil, fmt.Errorf("print section must not be empty")
-	}
-
-	for _, section := range sections {
-		if (section == PrintTyped || section == PrintFull) && len(sections) > 1 {
-			return nil, fmt.Errorf("print section %q cannot be combined with other sections", section)
-		}
-	}
-	return sections, nil
+	return printSectionsFromScalarAppendix(sections), nil
 }
 
 type explainMode string
@@ -724,11 +684,6 @@ type printResultOptions struct {
 
 func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions) (string, error) {
 	var b strings.Builder
-	resolveVars := printOpts.resolveScalarVars || printOpts.resolveScalarVarsRecursive
-	var resolver scalarLinkResolver
-	if resolveVars && needsScalarLinkResolver(printOpts.printSections) {
-		resolver = newScalarLinkResolver(rows)
-	}
 
 	if len(rows) > 0 && len(printOpts.renderDef.Columns) > 0 {
 		tablePart, err := renderTablePart(printOpts.renderDef, rows)
@@ -738,245 +693,39 @@ func printResult(rows []plantree.RowWithPredicates, printOpts printResultOptions
 		b.WriteString(tablePart)
 	}
 
-	for _, section := range printOpts.printSections {
-		var (
-			part string
-			err  error
-		)
-		switch section {
-		case PrintFull, PrintTyped:
-			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
-				"Node Parameters(identified by ID):",
-				func(row plantree.RowWithPredicates) []string {
-					return scalarLinkLines(row, func(_ plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
-						return section == PrintFull || link.Type != ""
-					}, formatRawScalarLink)
-				},
-			))
-		case PrintPredicates:
-			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
-				"Predicates(identified by ID):",
-				func(row plantree.RowWithPredicates) []string {
-					return row.Predicates
-				},
-			))
-		case PrintOrdering:
-			format := semanticScalarLinkFormatter(printOpts.showScalarVars, keyScalarLinkDescription)
-			if resolveVars {
-				format = semanticScalarLinkFormatter(printOpts.showScalarVars, func(link plantree.ScalarChildLink) string {
-					return resolver.formatKeyScalarLink(link, printOpts.resolveScalarVarsRecursive)
-				})
-			}
-			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
-				"Ordering(identified by ID):",
-				func(row plantree.RowWithPredicates) []string {
-					return scalarLinkLines(row, isOrderingScalarLink, format)
-				},
-			))
-		case PrintAggregate:
-			format := semanticScalarLinkFormatter(printOpts.showScalarVars, scalarLinkDescription)
-			if resolveVars {
-				format = semanticScalarLinkFormatter(printOpts.showScalarVars, func(link plantree.ScalarChildLink) string {
-					return resolver.formatAggregateScalarLink(link, printOpts.resolveScalarVarsRecursive)
-				})
-			}
-			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
-				"Aggregates(identified by ID):",
-				func(row plantree.RowWithPredicates) []string {
-					return scalarLinkLines(row, isAggregateScalarLink, format)
-				},
-			))
-		default:
-			return "", fmt.Errorf("unsupported print section: %s", section)
+	sections := scalarAppendixSections(printOpts.printSections)
+	appendixPart, err := scalarappendix.Render(rows, scalarappendix.Options{
+		Sections:                   &sections,
+		ShowScalarVars:             printOpts.showScalarVars,
+		ResolveScalarVars:          printOpts.resolveScalarVars,
+		ResolveScalarVarsRecursive: printOpts.resolveScalarVarsRecursive,
+	})
+	if err != nil {
+		return "", err
+	}
+	if appendixPart != "" {
+		if b.Len() > 0 {
+			b.WriteString("\n")
 		}
-		if err != nil {
-			return "", err
-		}
-		if part != "" {
-			if b.Len() > 0 {
-				b.WriteString("\n")
-			}
-			b.WriteString(part)
-		}
+		b.WriteString(appendixPart)
 	}
 	return b.String(), nil
 }
 
-func needsScalarLinkResolver(printSections PrintSections) bool {
-	return slices.Contains(printSections, PrintOrdering) || slices.Contains(printSections, PrintAggregate)
-}
-
-func scalarAppendixSpec(title string, items func(row plantree.RowWithPredicates) []string) asciitable.AppendixSpec[plantree.RowWithPredicates] {
-	return asciitable.AppendixSpec[plantree.RowWithPredicates]{
-		Title: title,
-		ID: func(row plantree.RowWithPredicates) uint {
-			// Spanner PlanNode indexes are zero-based node positions, so they are
-			// non-negative when used as appendix display IDs.
-			return uint(row.ID)
-		},
-		Items: items,
+func scalarAppendixSections(sections PrintSections) scalarappendix.Sections {
+	converted := make(scalarappendix.Sections, 0, len(sections))
+	for _, section := range sections {
+		converted = append(converted, scalarappendix.Section(section))
 	}
+	return converted
 }
 
-type scalarLinkGroup struct {
-	typ    string
-	values []string
-}
-
-func scalarLinkLines(row plantree.RowWithPredicates, include func(plantree.RowWithPredicates, plantree.ScalarChildLink) bool, format func(plantree.ScalarChildLink) string) []string {
-	groupByType := map[string]int{}
-	var groups []scalarLinkGroup
-
-	for _, link := range row.ScalarChildLinks {
-		if !include(row, link) {
-			continue
-		}
-
-		groupIndex, ok := groupByType[link.Type]
-		if !ok {
-			groupIndex = len(groups)
-			groupByType[link.Type] = groupIndex
-			groups = append(groups, scalarLinkGroup{typ: link.Type})
-		}
-		groups[groupIndex].values = append(groups[groupIndex].values, format(link))
+func printSectionsFromScalarAppendix(sections scalarappendix.Sections) PrintSections {
+	converted := make(PrintSections, 0, len(sections))
+	for _, section := range sections {
+		converted = append(converted, PrintSection(section))
 	}
-
-	lines := make([]string, 0, len(groups))
-	for _, group := range groups {
-		joined := strings.Join(group.values, ", ")
-		if joined == "" {
-			continue
-		}
-		typePartStr := lo.Ternary(group.typ != "", group.typ+": ", "")
-		lines = append(lines, typePartStr+joined)
-	}
-	return lines
-}
-
-func formatRawScalarLink(link plantree.ScalarChildLink) string {
-	if link.Variable != "" {
-		return fmt.Sprintf("$%s=%s", link.Variable, link.Description)
-	}
-	return link.Description
-}
-
-func scalarLinkDescription(link plantree.ScalarChildLink) string {
-	return link.Description
-}
-
-func keyScalarLinkDescription(link plantree.ScalarChildLink) string {
-	return normalizeKeyOrderSuffix(link.Description)
-}
-
-func semanticScalarLinkFormatter(showVars bool, description func(plantree.ScalarChildLink) string) func(plantree.ScalarChildLink) string {
-	return func(link plantree.ScalarChildLink) string {
-		desc := description(link)
-		if showVars && link.Variable != "" {
-			return fmt.Sprintf("$%s=%s", link.Variable, desc)
-		}
-		return desc
-	}
-}
-
-type scalarLinkResolver struct {
-	variableToDescription map[string]string
-}
-
-func newScalarLinkResolver(rows []plantree.RowWithPredicates) scalarLinkResolver {
-	variableToDescription := map[string]string{}
-	for _, row := range rows {
-		for _, link := range row.ScalarChildLinks {
-			if link.Variable == "" {
-				continue
-			}
-			variableToDescription[link.Variable] = link.Description
-		}
-	}
-	return scalarLinkResolver{variableToDescription: variableToDescription}
-}
-
-func (r scalarLinkResolver) formatKeyScalarLink(link plantree.ScalarChildLink, recursive bool) string {
-	return r.resolveKeyDescription(link.Description, recursive)
-}
-
-func (r scalarLinkResolver) formatAggregateScalarLink(link plantree.ScalarChildLink, recursive bool) string {
-	if link.Type == "Key" {
-		return r.resolveKeyDescription(link.Description, recursive)
-	}
-	return link.Description
-}
-
-func (r scalarLinkResolver) resolveKeyDescription(desc string, recursive bool) string {
-	if !recursive {
-		return normalizeKeyOrderSuffix(r.resolveDirectDescriptionVariables(desc))
-	}
-	return normalizeKeyOrderSuffix(r.resolveDescriptionVariables(desc, map[string]bool{}))
-}
-
-func (r scalarLinkResolver) resolveDirectDescriptionVariables(desc string) string {
-	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
-		desc, ok := r.variableToDescription[strings.TrimPrefix(ref, "$")]
-		if !ok {
-			return ref
-		}
-		return strings.TrimSpace(desc)
-	})
-}
-
-func (r scalarLinkResolver) resolveDescriptionVariables(desc string, seen map[string]bool) string {
-	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
-		return r.lookupVarRecursive(ref, seen)
-	})
-}
-
-func (r scalarLinkResolver) lookupVarRecursive(ref string, seen map[string]bool) string {
-	if !strings.HasPrefix(ref, "$") {
-		return ref
-	}
-
-	varName := strings.TrimPrefix(ref, "$")
-	if seen[varName] {
-		return ref
-	}
-
-	desc, ok := r.variableToDescription[varName]
-	if !ok {
-		return ref
-	}
-
-	seen[varName] = true
-	defer delete(seen, varName)
-
-	desc = strings.TrimSpace(desc)
-	if scalarVariableDescriptionRe.MatchString(desc) {
-		return r.lookupVarRecursive(desc, seen)
-	}
-	return r.resolveDescriptionVariables(desc, seen)
-}
-
-func normalizeKeyOrderSuffix(s string) string {
-	s = strings.TrimSpace(s)
-	for _, suffix := range []string{"(ASC)", "(DESC)"} {
-		if strings.HasSuffix(s, " "+suffix) {
-			return strings.TrimSuffix(s, " "+suffix) + " " + strings.Trim(suffix, "()")
-		}
-	}
-	return s
-}
-
-func isOrderingScalarLink(row plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
-	switch row.DisplayName {
-	case "Sort", "Sort Limit":
-		return link.Type == "Key"
-	case "Minor Sort", "Minor Sort Limit":
-		return link.Type == "MajorKey" || link.Type == "MinorKey"
-	default:
-		return false
-	}
-}
-
-func isAggregateScalarLink(row plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
-	return row.DisplayName == "Aggregate" && (link.Type == "Key" || link.Type == "Agg")
+	return converted
 }
 
 type renderedTableRow []string

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -691,6 +691,11 @@ func TestParsePrintSections(t *testing.T) {
 			want:  PrintSections{PrintPredicates, PrintOrdering},
 		},
 		{
+			name:  "empty means no sections",
+			input: "",
+			want:  PrintSections{},
+		},
+		{
 			name:    "unknown",
 			input:   "broken",
 			wantErr: "unknown print section: broken",
@@ -913,6 +918,25 @@ func TestRun_UsageErrors(t *testing.T) {
 				t.Fatalf("stdout = %q, want empty", stdout.String())
 			}
 		})
+	}
+}
+
+func TestRun_EmptyPrintSuppressesAppendix(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := run([]string{"-print", "", "-mode", "plan"}, bytes.NewReader(dcaYAML), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Predicates(identified by ID):") {
+		t.Fatalf("stdout contains predicates appendix despite -print empty:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Distributed Cross Apply") {
+		t.Fatalf("stdout = %q, want rendered tree", stdout.String())
 	}
 }
 

--- a/internal/scalarappendix/appendix.go
+++ b/internal/scalarappendix/appendix.go
@@ -1,0 +1,398 @@
+package scalarappendix
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/apstndb/spannerplan/asciitable"
+	"github.com/apstndb/spannerplan/plantree"
+)
+
+var (
+	scalarVariableReferenceRe   = regexp.MustCompile(`\$[A-Za-z0-9_']+(?:\.[A-Za-z0-9_']+)*`)
+	scalarVariableDescriptionRe = regexp.MustCompile(`^\$[A-Za-z0-9_']+(?:\.[A-Za-z0-9_']+)*$`)
+)
+
+// Section selects one appendix section printed after a rendered tree table.
+type Section string
+
+const (
+	// SectionPredicates prints predicate-like scalar links.
+	SectionPredicates Section = "predicates"
+	// SectionOrdering prints ordering scalar links for sort operators.
+	SectionOrdering Section = "ordering"
+	// SectionAggregate prints grouping and aggregate scalar links for aggregate operators.
+	SectionAggregate Section = "aggregate"
+	// SectionTyped prints all typed scalar links as a raw debug dump.
+	SectionTyped Section = "typed"
+	// SectionFull prints all scalar links, including unnamed links, as a raw debug dump.
+	SectionFull Section = "full"
+)
+
+// Sections is an ordered list of appendix sections.
+type Sections []Section
+
+// Options configures appendix rendering.
+type Options struct {
+	// Sections selects appendix sections.
+	// A nil value uses the default SectionPredicates section.
+	// An explicitly empty value renders no appendix sections.
+	Sections *Sections
+
+	// ShowScalarVars prints scalar assignment variable names in semantic appendix sections.
+	ShowScalarVars bool
+
+	// ResolveScalarVars replaces direct scalar variable aliases in semantic appendix sections.
+	ResolveScalarVars bool
+
+	// ResolveScalarVarsRecursive recursively resolves scalar variable aliases in semantic appendix sections.
+	ResolveScalarVarsRecursive bool
+}
+
+// ParseSection parses one print-section name.
+// Valid values are "predicates", "ordering", "aggregate", "typed", and "full" (case-insensitive).
+func ParseSection(s string) (Section, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case string(SectionPredicates):
+		return SectionPredicates, nil
+	case string(SectionOrdering):
+		return SectionOrdering, nil
+	case string(SectionAggregate):
+		return SectionAggregate, nil
+	case string(SectionTyped):
+		return SectionTyped, nil
+	case string(SectionFull):
+		return SectionFull, nil
+	default:
+		return "", fmt.Errorf("unknown print section: %s", s)
+	}
+}
+
+// ParseSections parses a comma-separated print-section list.
+func ParseSections(s string) (Sections, error) {
+	var sections Sections
+	for _, raw := range strings.Split(s, ",") {
+		if strings.TrimSpace(raw) == "" {
+			return nil, fmt.Errorf("print section must not be empty")
+		}
+
+		section, err := ParseSection(raw)
+		if err != nil {
+			return nil, err
+		}
+		sections = append(sections, section)
+	}
+
+	if len(sections) == 0 {
+		return nil, fmt.Errorf("print section must not be empty")
+	}
+	if err := ValidateSections(sections); err != nil {
+		return nil, err
+	}
+	return sections, nil
+}
+
+// ValidateSections validates an ordered print-section list.
+func ValidateSections(sections Sections) error {
+	seen := map[Section]bool{}
+	for _, section := range sections {
+		switch section {
+		case SectionPredicates, SectionOrdering, SectionAggregate, SectionTyped, SectionFull:
+		default:
+			return fmt.Errorf("unsupported print section: %s", section)
+		}
+
+		if seen[section] {
+			return fmt.Errorf("duplicate print section: %s", section)
+		}
+		seen[section] = true
+	}
+
+	if len(sections) > 1 {
+		for _, section := range sections {
+			if section == SectionTyped || section == SectionFull {
+				return fmt.Errorf("print section %q cannot be combined with other sections", section)
+			}
+		}
+	}
+	return nil
+}
+
+// Render renders the configured scalar appendices without a leading separator.
+func Render(rows []plantree.RowWithPredicates, opts Options) (string, error) {
+	sections, err := resolvedSections(opts.Sections)
+	if err != nil {
+		return "", err
+	}
+
+	resolveVars := opts.ResolveScalarVars || opts.ResolveScalarVarsRecursive
+	var resolver scalarLinkResolver
+	if resolveVars && needsScalarLinkResolver(sections) {
+		resolver = newScalarLinkResolver(rows)
+	}
+
+	var b strings.Builder
+	for _, section := range sections {
+		var (
+			part string
+			err  error
+		)
+		switch section {
+		case SectionFull, SectionTyped:
+			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
+				"Node Parameters(identified by ID):",
+				func(row plantree.RowWithPredicates) []string {
+					return scalarLinkLines(row, func(_ plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
+						return section == SectionFull || link.Type != ""
+					}, formatRawScalarLink)
+				},
+			))
+		case SectionPredicates:
+			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
+				"Predicates(identified by ID):",
+				func(row plantree.RowWithPredicates) []string {
+					return row.Predicates
+				},
+			))
+		case SectionOrdering:
+			format := semanticScalarLinkFormatter(opts.ShowScalarVars, keyScalarLinkDescription)
+			if resolveVars {
+				format = semanticScalarLinkFormatter(opts.ShowScalarVars, func(link plantree.ScalarChildLink) string {
+					return resolver.formatKeyScalarLink(link, opts.ResolveScalarVarsRecursive)
+				})
+			}
+			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
+				"Ordering(identified by ID):",
+				func(row plantree.RowWithPredicates) []string {
+					return scalarLinkLines(row, isOrderingScalarLink, format)
+				},
+			))
+		case SectionAggregate:
+			format := semanticScalarLinkFormatter(opts.ShowScalarVars, scalarLinkDescription)
+			if resolveVars {
+				format = semanticScalarLinkFormatter(opts.ShowScalarVars, func(link plantree.ScalarChildLink) string {
+					return resolver.formatAggregateScalarLink(link, opts.ResolveScalarVarsRecursive)
+				})
+			}
+			part, err = asciitable.RenderAppendix(rows, scalarAppendixSpec(
+				"Aggregates(identified by ID):",
+				func(row plantree.RowWithPredicates) []string {
+					return scalarLinkLines(row, isAggregateScalarLink, format)
+				},
+			))
+		default:
+			return "", fmt.Errorf("unsupported print section: %s", section)
+		}
+		if err != nil {
+			return "", err
+		}
+		if part != "" {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(part)
+		}
+	}
+	return b.String(), nil
+}
+
+func resolvedSections(sections *Sections) (Sections, error) {
+	if sections == nil {
+		return Sections{SectionPredicates}, nil
+	}
+	resolved := append(Sections{}, (*sections)...)
+	return resolved, ValidateSections(resolved)
+}
+
+func needsScalarLinkResolver(sections Sections) bool {
+	return slices.Contains(sections, SectionOrdering) || slices.Contains(sections, SectionAggregate)
+}
+
+func scalarAppendixSpec(
+	title string,
+	items func(row plantree.RowWithPredicates) []string,
+) asciitable.AppendixSpec[plantree.RowWithPredicates] {
+	return asciitable.AppendixSpec[plantree.RowWithPredicates]{
+		Title: title,
+		ID: func(row plantree.RowWithPredicates) uint {
+			// Spanner PlanNode indexes are zero-based node positions, so they are
+			// non-negative when used as appendix display IDs.
+			return uint(row.ID)
+		},
+		Items: items,
+	}
+}
+
+type scalarLinkGroup struct {
+	typ    string
+	values []string
+}
+
+func scalarLinkLines(
+	row plantree.RowWithPredicates,
+	include func(plantree.RowWithPredicates, plantree.ScalarChildLink) bool,
+	format func(plantree.ScalarChildLink) string,
+) []string {
+	groupByType := map[string]int{}
+	groups := []scalarLinkGroup{}
+
+	for _, link := range row.ScalarChildLinks {
+		if !include(row, link) {
+			continue
+		}
+
+		groupIndex, ok := groupByType[link.Type]
+		if !ok {
+			groupIndex = len(groups)
+			groupByType[link.Type] = groupIndex
+			groups = append(groups, scalarLinkGroup{typ: link.Type})
+		}
+		groups[groupIndex].values = append(groups[groupIndex].values, format(link))
+	}
+
+	lines := make([]string, 0, len(groups))
+	for _, group := range groups {
+		joined := strings.Join(group.values, ", ")
+		if joined == "" {
+			continue
+		}
+
+		typePart := ""
+		if group.typ != "" {
+			typePart = group.typ + ": "
+		}
+		lines = append(lines, typePart+joined)
+	}
+	return lines
+}
+
+func formatRawScalarLink(link plantree.ScalarChildLink) string {
+	if link.Variable != "" {
+		return fmt.Sprintf("$%s=%s", link.Variable, link.Description)
+	}
+	return link.Description
+}
+
+func scalarLinkDescription(link plantree.ScalarChildLink) string {
+	return link.Description
+}
+
+func keyScalarLinkDescription(link plantree.ScalarChildLink) string {
+	return normalizeKeyOrderSuffix(link.Description)
+}
+
+func semanticScalarLinkFormatter(
+	showVars bool,
+	description func(plantree.ScalarChildLink) string,
+) func(plantree.ScalarChildLink) string {
+	return func(link plantree.ScalarChildLink) string {
+		desc := description(link)
+		if showVars && link.Variable != "" {
+			return fmt.Sprintf("$%s=%s", link.Variable, desc)
+		}
+		return desc
+	}
+}
+
+type scalarLinkResolver struct {
+	variableToDescription map[string]string
+}
+
+func newScalarLinkResolver(rows []plantree.RowWithPredicates) scalarLinkResolver {
+	variableToDescription := map[string]string{}
+	for _, row := range rows {
+		for _, link := range row.ScalarChildLinks {
+			if link.Variable == "" {
+				continue
+			}
+			variableToDescription[link.Variable] = link.Description
+		}
+	}
+	return scalarLinkResolver{variableToDescription: variableToDescription}
+}
+
+func (r scalarLinkResolver) formatKeyScalarLink(link plantree.ScalarChildLink, recursive bool) string {
+	return r.resolveKeyDescription(link.Description, recursive)
+}
+
+func (r scalarLinkResolver) formatAggregateScalarLink(link plantree.ScalarChildLink, recursive bool) string {
+	if link.Type == "Key" {
+		return r.resolveKeyDescription(link.Description, recursive)
+	}
+	return link.Description
+}
+
+func (r scalarLinkResolver) resolveKeyDescription(desc string, recursive bool) string {
+	if !recursive {
+		return normalizeKeyOrderSuffix(r.resolveDirectDescriptionVariables(desc))
+	}
+	return normalizeKeyOrderSuffix(r.resolveDescriptionVariables(desc, map[string]bool{}))
+}
+
+func (r scalarLinkResolver) resolveDirectDescriptionVariables(desc string) string {
+	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
+		desc, ok := r.variableToDescription[strings.TrimPrefix(ref, "$")]
+		if !ok {
+			return ref
+		}
+		return strings.TrimSpace(desc)
+	})
+}
+
+func (r scalarLinkResolver) resolveDescriptionVariables(desc string, seen map[string]bool) string {
+	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
+		return r.lookupVarRecursive(ref, seen)
+	})
+}
+
+func (r scalarLinkResolver) lookupVarRecursive(ref string, seen map[string]bool) string {
+	if !strings.HasPrefix(ref, "$") {
+		return ref
+	}
+
+	varName := strings.TrimPrefix(ref, "$")
+	if seen[varName] {
+		return ref
+	}
+
+	desc, ok := r.variableToDescription[varName]
+	if !ok {
+		return ref
+	}
+
+	seen[varName] = true
+	defer delete(seen, varName)
+
+	desc = strings.TrimSpace(desc)
+	if scalarVariableDescriptionRe.MatchString(desc) {
+		return r.lookupVarRecursive(desc, seen)
+	}
+	return r.resolveDescriptionVariables(desc, seen)
+}
+
+func normalizeKeyOrderSuffix(s string) string {
+	s = strings.TrimSpace(s)
+	for _, suffix := range []string{"(ASC)", "(DESC)"} {
+		if strings.HasSuffix(s, " "+suffix) {
+			return strings.TrimSuffix(s, " "+suffix) + " " + strings.Trim(suffix, "()")
+		}
+	}
+	return s
+}
+
+func isOrderingScalarLink(row plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
+	switch row.DisplayName {
+	case "Sort", "Sort Limit":
+		return link.Type == "Key"
+	case "Minor Sort", "Minor Sort Limit":
+		return link.Type == "MajorKey" || link.Type == "MinorKey"
+	default:
+		return false
+	}
+}
+
+func isAggregateScalarLink(row plantree.RowWithPredicates, link plantree.ScalarChildLink) bool {
+	return row.DisplayName == "Aggregate" && (link.Type == "Key" || link.Type == "Agg")
+}

--- a/internal/scalarappendix/appendix.go
+++ b/internal/scalarappendix/appendix.go
@@ -335,11 +335,11 @@ func (r scalarLinkResolver) resolveKeyDescription(desc string, recursive bool) s
 
 func (r scalarLinkResolver) resolveDirectDescriptionVariables(desc string) string {
 	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
-		desc, ok := r.variableToDescription[ref[1:]]
+		resolved, ok := r.variableToDescription[strings.TrimPrefix(ref, "$")]
 		if !ok {
 			return ref
 		}
-		return strings.TrimSpace(desc)
+		return strings.TrimSpace(resolved)
 	})
 }
 
@@ -354,7 +354,7 @@ func (r scalarLinkResolver) lookupVarRecursive(ref string, seen map[string]bool)
 		return ref
 	}
 
-	varName := ref[1:]
+	varName := strings.TrimPrefix(ref, "$")
 	if seen[varName] {
 		return ref
 	}

--- a/internal/scalarappendix/appendix.go
+++ b/internal/scalarappendix/appendix.go
@@ -90,9 +90,6 @@ func ParseSections(s string) (Sections, error) {
 		sections = append(sections, section)
 	}
 
-	if len(sections) == 0 {
-		return nil, fmt.Errorf("print section must not be empty")
-	}
 	if err := ValidateSections(sections); err != nil {
 		return nil, err
 	}
@@ -338,7 +335,7 @@ func (r scalarLinkResolver) resolveKeyDescription(desc string, recursive bool) s
 
 func (r scalarLinkResolver) resolveDirectDescriptionVariables(desc string) string {
 	return scalarVariableReferenceRe.ReplaceAllStringFunc(desc, func(ref string) string {
-		desc, ok := r.variableToDescription[strings.TrimPrefix(ref, "$")]
+		desc, ok := r.variableToDescription[ref[1:]]
 		if !ok {
 			return ref
 		}
@@ -357,7 +354,7 @@ func (r scalarLinkResolver) lookupVarRecursive(ref string, seen map[string]bool)
 		return ref
 	}
 
-	varName := strings.TrimPrefix(ref, "$")
+	varName := ref[1:]
 	if seen[varName] {
 		return ref
 	}

--- a/internal/scalarappendix/appendix.go
+++ b/internal/scalarappendix/appendix.go
@@ -71,7 +71,12 @@ func ParseSection(s string) (Section, error) {
 }
 
 // ParseSections parses a comma-separated print-section list.
+// An empty string returns an empty list, which renders no appendix sections.
 func ParseSections(s string) (Sections, error) {
+	if strings.TrimSpace(s) == "" {
+		return Sections{}, nil
+	}
+
 	var sections Sections
 	for _, raw := range strings.Split(s, ",") {
 		if strings.TrimSpace(raw) == "" {

--- a/internal/scalarappendix/appendix_test.go
+++ b/internal/scalarappendix/appendix_test.go
@@ -1,0 +1,236 @@
+package scalarappendix
+
+import (
+	"strings"
+	"testing"
+
+	heredoc "github.com/MakeNowJust/heredoc/v2"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/apstndb/spannerplan/plantree"
+)
+
+func TestParseSections(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Sections
+		wantErr string
+	}{
+		{
+			name:  "single section",
+			input: "predicates",
+			want:  Sections{SectionPredicates},
+		},
+		{
+			name:  "multiple sections",
+			input: " Predicates, Ordering, aggregate ",
+			want:  Sections{SectionPredicates, SectionOrdering, SectionAggregate},
+		},
+		{
+			name:    "empty element",
+			input:   "predicates,",
+			wantErr: "print section must not be empty",
+		},
+		{
+			name:    "unknown",
+			input:   "broken",
+			wantErr: "unknown print section: broken",
+		},
+		{
+			name:    "duplicate",
+			input:   "predicates,predicates",
+			wantErr: "duplicate print section: predicates",
+		},
+		{
+			name:    "raw dump cannot be combined",
+			input:   "predicates,full",
+			wantErr: `print section "full" cannot be combined with other sections`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSections(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("ParseSections() error = nil, want non-nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ParseSections() error = %q, want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSections() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("ParseSections() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRender(t *testing.T) {
+	rows := scalarAppendixRows()
+
+	sections := Sections{SectionPredicates, SectionOrdering, SectionAggregate}
+	got, err := Render(rows, Options{Sections: &sections})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	want := heredoc.Doc(`
+Predicates(identified by ID):
+ 2: Condition: ($SingerId = $SingerId_1)
+
+Ordering(identified by ID):
+ 0: Key: $SongCount DESC, $group_SongGenre'
+
+Aggregates(identified by ID):
+ 1: Key: $group_SongGenre
+    Agg: COUNT_FINAL($v1)
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("Render() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRenderDefaultAndEmptySections(t *testing.T) {
+	rows := scalarAppendixRows()
+
+	got, err := Render(rows, Options{})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	want := heredoc.Doc(`
+Predicates(identified by ID):
+ 2: Condition: ($SingerId = $SingerId_1)
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("Render() default sections mismatch (-want +got):\n%s", diff)
+	}
+
+	sections := Sections{}
+	got, err = Render(rows, Options{Sections: &sections})
+	if err != nil {
+		t.Fatalf("Render(empty sections) error = %v", err)
+	}
+	if got != "" {
+		t.Fatalf("Render(empty sections) = %q, want empty", got)
+	}
+}
+
+func TestRenderResolveScalarVars(t *testing.T) {
+	rows := scalarAppendixRows()
+	sections := Sections{SectionOrdering, SectionAggregate}
+
+	got, err := Render(rows, Options{
+		Sections:                   &sections,
+		ShowScalarVars:             true,
+		ResolveScalarVarsRecursive: true,
+	})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	want := heredoc.Doc(`
+Ordering(identified by ID):
+ 0: Key: $sort_count=COUNT_FINAL(COUNT()) DESC, $sort_genre=SongGenre
+
+Aggregates(identified by ID):
+ 1: Key: $group_SongGenre'=SongGenre
+    Agg: $SongCount=COUNT_FINAL($v1)
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("Render() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRenderRawSections(t *testing.T) {
+	rows := scalarAppendixRows()
+
+	sections := Sections{SectionTyped}
+	got, err := Render(rows, Options{Sections: &sections})
+	if err != nil {
+		t.Fatalf("Render(typed) error = %v", err)
+	}
+	want := heredoc.Doc(`
+Node Parameters(identified by ID):
+ 0: Key: $sort_count=$SongCount (DESC), $sort_genre=$group_SongGenre'
+ 1: Key: $group_SongGenre'=$group_SongGenre
+    Agg: $SongCount=COUNT_FINAL($v1)
+ 2: Condition: ($SingerId = $SingerId_1)
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("Render(typed) mismatch (-want +got):\n%s", diff)
+	}
+
+	sections = Sections{SectionFull}
+	got, err = Render(rows, Options{Sections: &sections})
+	if err != nil {
+		t.Fatalf("Render(full) error = %v", err)
+	}
+	want = heredoc.Doc(`
+Node Parameters(identified by ID):
+ 0: Key: $sort_count=$SongCount (DESC), $sort_genre=$group_SongGenre'
+ 1: Key: $group_SongGenre'=$group_SongGenre
+    Agg: $SongCount=COUNT_FINAL($v1)
+ 2: Condition: ($SingerId = $SingerId_1)
+ 3: $group_SongGenre=$SongGenre, $SongGenre=SongGenre, $v1=COUNT()
+`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("Render(full) mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRenderUnsupportedSection(t *testing.T) {
+	sections := Sections{"broken"}
+	_, err := Render(nil, Options{Sections: &sections})
+	if err == nil {
+		t.Fatal("Render() error = nil, want non-nil")
+	}
+	if got, want := err.Error(), "unsupported print section: broken"; got != want {
+		t.Fatalf("Render() error = %q, want %q", got, want)
+	}
+}
+
+func scalarAppendixRows() []plantree.RowWithPredicates {
+	return []plantree.RowWithPredicates{
+		{
+			ID:          0,
+			DisplayName: "Sort",
+			NodeText:    "Sort",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Type: "Key", Variable: "sort_count", Description: "$SongCount (DESC)"},
+				{Type: "Key", Variable: "sort_genre", Description: "$group_SongGenre'"},
+			},
+		},
+		{
+			ID:          1,
+			DisplayName: "Aggregate",
+			NodeText:    "Aggregate",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Type: "Key", Variable: "group_SongGenre'", Description: "$group_SongGenre"},
+				{Type: "Agg", Variable: "SongCount", Description: "COUNT_FINAL($v1)"},
+			},
+		},
+		{
+			ID:          2,
+			DisplayName: "Filter",
+			NodeText:    "Filter",
+			Predicates:  []string{"Condition: ($SingerId = $SingerId_1)"},
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Type: "Condition", Description: "($SingerId = $SingerId_1)"},
+			},
+		},
+		{
+			ID:          3,
+			DisplayName: "Scan",
+			NodeText:    "Scan",
+			ScalarChildLinks: []plantree.ScalarChildLink{
+				{Variable: "group_SongGenre", Description: "$SongGenre"},
+				{Variable: "SongGenre", Description: "SongGenre"},
+				{Variable: "v1", Description: "COUNT()"},
+			},
+		},
+	}
+}

--- a/internal/scalarappendix/appendix_test.go
+++ b/internal/scalarappendix/appendix_test.go
@@ -28,6 +28,16 @@ func TestParseSections(t *testing.T) {
 			want:  Sections{SectionPredicates, SectionOrdering, SectionAggregate},
 		},
 		{
+			name:  "empty means no sections",
+			input: "",
+			want:  Sections{},
+		},
+		{
+			name:  "blank means no sections",
+			input: " \t ",
+			want:  Sections{},
+		},
+		{
 			name:    "empty element",
 			input:   "predicates,",
 			wantErr: "print section must not be empty",

--- a/plantree/reference/appendix.go
+++ b/plantree/reference/appendix.go
@@ -1,0 +1,75 @@
+package reference
+
+import (
+	"github.com/apstndb/spannerplan/internal/scalarappendix"
+	"github.com/apstndb/spannerplan/plantree"
+)
+
+// PrintSection selects one appendix section printed after the rendered tree table.
+type PrintSection string
+
+const (
+	// PrintPredicates prints predicate-like scalar links.
+	PrintPredicates PrintSection = "predicates"
+	// PrintOrdering prints ordering scalar links for sort operators.
+	PrintOrdering PrintSection = "ordering"
+	// PrintAggregate prints grouping and aggregate scalar links for aggregate operators.
+	PrintAggregate PrintSection = "aggregate"
+	// PrintTyped prints all typed scalar links as a raw debug dump.
+	PrintTyped PrintSection = "typed"
+	// PrintFull prints all scalar links, including unnamed links, as a raw debug dump.
+	PrintFull PrintSection = "full"
+)
+
+// PrintSections is an ordered list of appendix sections.
+type PrintSections []PrintSection
+
+// ParsePrintSection parses one print-section name.
+// Valid values are "predicates", "ordering", "aggregate", "typed", and "full" (case-insensitive).
+func ParsePrintSection(s string) (PrintSection, error) {
+	section, err := scalarappendix.ParseSection(s)
+	return PrintSection(section), err
+}
+
+// ParsePrintSections parses a comma-separated print-section list.
+func ParsePrintSections(s string) (PrintSections, error) {
+	sections, err := scalarappendix.ParseSections(s)
+	if err != nil {
+		return nil, err
+	}
+	return printSectionsFromScalarAppendix(sections), nil
+}
+
+func printOptionsFromOptions(o options) scalarappendix.Options {
+	var sections *scalarappendix.Sections
+	if o.printSections != nil {
+		converted := scalarAppendixSections(*o.printSections)
+		sections = &converted
+	}
+	return scalarappendix.Options{
+		Sections:                   sections,
+		ShowScalarVars:             o.showScalarVars,
+		ResolveScalarVars:          o.resolveScalarVars,
+		ResolveScalarVarsRecursive: o.resolveScalarVarsRecursive,
+	}
+}
+
+func renderAppendices(rows []plantree.RowWithPredicates, printOpts scalarappendix.Options) (string, error) {
+	return scalarappendix.Render(rows, printOpts)
+}
+
+func scalarAppendixSections(sections PrintSections) scalarappendix.Sections {
+	converted := make(scalarappendix.Sections, 0, len(sections))
+	for _, section := range sections {
+		converted = append(converted, scalarappendix.Section(section))
+	}
+	return converted
+}
+
+func printSectionsFromScalarAppendix(sections scalarappendix.Sections) PrintSections {
+	converted := make(PrintSections, 0, len(sections))
+	for _, section := range sections {
+		converted = append(converted, PrintSection(section))
+	}
+	return converted
+}

--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -40,8 +40,12 @@ const (
 )
 
 type options struct {
-	wrapWidth     int
-	hangingIndent bool
+	wrapWidth                  int
+	hangingIndent              bool
+	printSections              *PrintSections
+	showScalarVars             bool
+	resolveScalarVars          bool
+	resolveScalarVarsRecursive bool
 }
 
 // RenderConfig configures optional rendering behavior using serialization-friendly fields.
@@ -57,6 +61,21 @@ type RenderConfig struct {
 	// HangingIndent hangs wrapped continuation lines after node-local prefixes such as
 	// `[Input] ` and `[Map] ` instead of keeping the default tree-aligned indentation.
 	HangingIndent bool `json:"hangingIndent,omitempty"`
+
+	// PrintSections selects appendix sections printed after the rendered tree table.
+	// A nil slice uses the default [PrintPredicates] section for compatibility.
+	// In JSON config, omit this field or set it to null to use the default; set
+	// it to [] to print no appendix sections.
+	PrintSections PrintSections `json:"printSections"`
+
+	// ShowScalarVars prints scalar assignment variable names in semantic appendix sections.
+	ShowScalarVars bool `json:"showScalarVars,omitempty"`
+
+	// ResolveScalarVars replaces direct scalar variable aliases in semantic appendix sections.
+	ResolveScalarVars bool `json:"resolveScalarVars,omitempty"`
+
+	// ResolveScalarVarsRecursive recursively resolves scalar variable aliases in semantic appendix sections.
+	ResolveScalarVarsRecursive bool `json:"resolveScalarVarsRecursive,omitempty"`
 }
 
 // Option configures optional rendering behavior for [RenderTreeTableWithOptions].
@@ -75,6 +94,37 @@ func WithWrapWidth(width int) Option {
 func WithHangingIndent() Option {
 	return func(o *options) {
 		o.hangingIndent = true
+	}
+}
+
+// WithPrintSections selects appendix sections printed after the rendered tree table.
+// If this option is omitted, [PrintPredicates] is printed for compatibility.
+// Passing no sections suppresses appendices.
+func WithPrintSections(sections ...PrintSection) Option {
+	return func(o *options) {
+		copied := append(PrintSections{}, sections...)
+		o.printSections = &copied
+	}
+}
+
+// WithShowScalarVars prints scalar assignment variable names in semantic appendix sections.
+func WithShowScalarVars() Option {
+	return func(o *options) {
+		o.showScalarVars = true
+	}
+}
+
+// WithResolveScalarVars replaces direct scalar variable aliases in semantic appendix sections.
+func WithResolveScalarVars() Option {
+	return func(o *options) {
+		o.resolveScalarVars = true
+	}
+}
+
+// WithResolveScalarVarsRecursive recursively resolves scalar variable aliases in semantic appendix sections.
+func WithResolveScalarVarsRecursive() Option {
+	return func(o *options) {
+		o.resolveScalarVarsRecursive = true
 	}
 }
 
@@ -120,10 +170,18 @@ func RenderTreeTableWithOptions(planNodes []*sppb.PlanNode, mode RenderMode, for
 }
 
 func optionsFromConfig(config RenderConfig) options {
-	return options{
-		wrapWidth:     config.WrapWidth,
-		hangingIndent: config.HangingIndent,
+	o := options{
+		wrapWidth:                  config.WrapWidth,
+		hangingIndent:              config.HangingIndent,
+		showScalarVars:             config.ShowScalarVars,
+		resolveScalarVars:          config.ResolveScalarVars,
+		resolveScalarVarsRecursive: config.ResolveScalarVarsRecursive,
 	}
+	if config.PrintSections != nil {
+		copied := append(PrintSections{}, config.PrintSections...)
+		o.printSections = &copied
+	}
+	return o
 }
 
 func renderTreeTable(planNodes []*sppb.PlanNode, mode RenderMode, format Format, o options) (string, error) {
@@ -157,16 +215,12 @@ func renderTreeTable(planNodes []*sppb.PlanNode, mode RenderMode, format Format,
 		return "", err
 	}
 
-	predPart, err := renderPredicatesPart(rendered)
+	appendixPart, err := renderAppendices(rendered, printOptionsFromOptions(o))
 	if err != nil {
 		return "", err
 	}
 
-	return tablePart + predPart, nil
-}
-
-func renderPredicatesPart(rendered []plantree.RowWithPredicates) (string, error) {
-	return asciitable.RenderAppendix(rendered, predicateAppendixSpec())
+	return tablePart + appendixPart, nil
 }
 
 func renderTablePart(rendered []plantree.RowWithPredicates, withStats bool) (string, error) {
@@ -220,20 +274,6 @@ func spannerTableSpec(withStats bool) asciitable.TableSpec[plantree.RowWithPredi
 		},
 	)
 	return spec
-}
-
-func predicateAppendixSpec() asciitable.AppendixSpec[plantree.RowWithPredicates] {
-	return asciitable.AppendixSpec[plantree.RowWithPredicates]{
-		Title: "Predicates(identified by ID):",
-		ID: func(row plantree.RowWithPredicates) uint {
-			// Spanner PlanNode indexes are zero-based node positions, so they are
-			// non-negative when used as predicate appendix display IDs.
-			return uint(row.ID)
-		},
-		Items: func(row plantree.RowWithPredicates) []string {
-			return row.Predicates
-		},
-	}
 }
 
 // Format specifies the formatting style for the query plan output.

--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -63,10 +63,10 @@ type RenderConfig struct {
 	HangingIndent bool `json:"hangingIndent,omitempty"`
 
 	// PrintSections selects appendix sections printed after the rendered tree table.
-	// A nil slice uses the default [PrintPredicates] section for compatibility.
+	// A nil slice uses the default [PrintPredicates] section.
 	// In JSON config, omit this field or set it to null to use the default; set
 	// it to [] to print no appendix sections.
-	PrintSections PrintSections `json:"printSections"`
+	PrintSections PrintSections `json:"printSections,omitempty"`
 
 	// ShowScalarVars prints scalar assignment variable names in semantic appendix sections.
 	ShowScalarVars bool `json:"showScalarVars,omitempty"`

--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -63,10 +63,10 @@ type RenderConfig struct {
 	HangingIndent bool `json:"hangingIndent,omitempty"`
 
 	// PrintSections selects appendix sections printed after the rendered tree table.
-	// A nil slice uses the default [PrintPredicates] section.
+	// A nil pointer uses the default [PrintPredicates] section.
 	// In JSON config, omit this field or set it to null to use the default; set
 	// it to [] to print no appendix sections.
-	PrintSections PrintSections `json:"printSections,omitempty"`
+	PrintSections *PrintSections `json:"printSections,omitempty"`
 
 	// ShowScalarVars prints scalar assignment variable names in semantic appendix sections.
 	ShowScalarVars bool `json:"showScalarVars,omitempty"`
@@ -178,7 +178,7 @@ func optionsFromConfig(config RenderConfig) options {
 		resolveScalarVarsRecursive: config.ResolveScalarVarsRecursive,
 	}
 	if config.PrintSections != nil {
-		copied := append(PrintSections{}, config.PrintSections...)
+		copied := append(PrintSections{}, (*config.PrintSections)...)
 		o.printSections = &copied
 	}
 	return o

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -541,7 +541,7 @@ func TestRenderTreeTableWithConfig_PrintSections(t *testing.T) {
 		RenderModePlan,
 		FormatCurrent,
 		RenderConfig{
-			PrintSections:     PrintSections{PrintOrdering, PrintAggregate},
+			PrintSections:     printSectionsPtr(PrintOrdering, PrintAggregate),
 			ShowScalarVars:    true,
 			ResolveScalarVars: true,
 		},
@@ -627,16 +627,29 @@ func TestRenderTreeTableWithOptions_PrintSectionValidation(t *testing.T) {
 	}
 }
 
-func TestRenderConfigPrintSectionsJSONInputEmptySlice(t *testing.T) {
+func printSectionsPtr(sections ...PrintSection) *PrintSections {
+	copied := append(PrintSections{}, sections...)
+	return &copied
+}
+
+func TestRenderConfigPrintSectionsJSONRoundTripEmptySlice(t *testing.T) {
+	b, err := json.Marshal(RenderConfig{PrintSections: printSectionsPtr()})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if !strings.Contains(string(b), `"printSections":[]`) {
+		t.Fatalf("json.Marshal() = %s, want printSections to preserve explicit empty slice", b)
+	}
+
 	var got RenderConfig
-	if err := json.Unmarshal([]byte(`{"printSections":[]}`), &got); err != nil {
+	if err := json.Unmarshal(b, &got); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 	if got.PrintSections == nil {
-		t.Fatal("json.Unmarshal() left PrintSections nil, want explicit empty slice")
+		t.Fatal("json round trip left PrintSections nil, want explicit empty slice")
 	}
-	if len(got.PrintSections) != 0 {
-		t.Fatalf("json.Unmarshal() PrintSections = %#v, want empty", got.PrintSections)
+	if len(*got.PrintSections) != 0 {
+		t.Fatalf("json round trip PrintSections = %#v, want empty", *got.PrintSections)
 	}
 
 	rendered, err := RenderTreeTableWithConfig(

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -1,6 +1,7 @@
 package reference
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -28,6 +29,59 @@ func loadWrappedPlan(t *testing.T) string {
 		t.Fatalf("failed to read wrapped plan fixture: %v", err)
 	}
 	return string(b)
+}
+
+func scalarAppendixPlanNodes() []*sppb.PlanNode {
+	return []*sppb.PlanNode{
+		{
+			Index:       0,
+			DisplayName: "Sort",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 1, Type: "Key", Variable: "sort_count"},
+				{ChildIndex: 2, Type: "Key", Variable: "sort_genre"},
+				{ChildIndex: 3},
+			},
+		},
+		scalarPlanNode(1, "$SongCount (DESC)"),
+		scalarPlanNode(2, "$group_SongGenre'"),
+		{
+			Index:       3,
+			DisplayName: "Aggregate",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 4, Type: "Key", Variable: "group_SongGenre'"},
+				{ChildIndex: 5, Type: "Agg", Variable: "SongCount"},
+				{ChildIndex: 6},
+			},
+		},
+		scalarPlanNode(4, "$group_SongGenre"),
+		scalarPlanNode(5, "COUNT_FINAL($v1)"),
+		{
+			Index:       6,
+			DisplayName: "Scan",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 7, Variable: "group_SongGenre"},
+				{ChildIndex: 8, Variable: "SongGenre"},
+				{ChildIndex: 9, Variable: "v1"},
+			},
+		},
+		scalarPlanNode(7, "$SongGenre"),
+		scalarPlanNode(8, "SongGenre"),
+		scalarPlanNode(9, "COUNT()"),
+	}
+}
+
+func scalarPlanNode(index int32, description string) *sppb.PlanNode {
+	return &sppb.PlanNode{
+		Index:       index,
+		DisplayName: "Reference",
+		Kind:        sppb.PlanNode_SCALAR,
+		ShortRepresentation: &sppb.PlanNode_ShortRepresentation{
+			Description: description,
+		},
+	}
 }
 
 func Test_RenderTreeTable_withRealPlan_ALL_MODES_AND_FORMATS(t *testing.T) {
@@ -333,6 +387,67 @@ func TestParseFormat(t *testing.T) {
 	}
 }
 
+func TestParsePrintSections(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    PrintSections
+		wantErr string
+	}{
+		{
+			name:  "single section",
+			input: "predicates",
+			want:  PrintSections{PrintPredicates},
+		},
+		{
+			name:  "multiple sections",
+			input: "predicates,ordering,aggregate",
+			want:  PrintSections{PrintPredicates, PrintOrdering, PrintAggregate},
+		},
+		{
+			name:  "case and space",
+			input: " Predicates, Ordering ",
+			want:  PrintSections{PrintPredicates, PrintOrdering},
+		},
+		{
+			name:    "unknown",
+			input:   "broken",
+			wantErr: "unknown print section: broken",
+		},
+		{
+			name:    "duplicate",
+			input:   "predicates,predicates",
+			wantErr: "duplicate print section: predicates",
+		},
+		{
+			name:    "raw dump cannot be combined",
+			input:   "predicates,full",
+			wantErr: `print section "full" cannot be combined with other sections`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePrintSections(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("ParsePrintSections() error = nil, want non-nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ParsePrintSections() error = %q, want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePrintSections() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("ParsePrintSections() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestRenderTreeTable_InvalidMode(t *testing.T) {
 	// Create minimal valid plan nodes
 	planNodes := []*sppb.PlanNode{{}}
@@ -384,6 +499,147 @@ func TestRenderTreeTable_InputValidation(t *testing.T) {
 				t.Errorf("expected error to contain %q, got: %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestRenderTreeTableWithOptions_PrintSections(t *testing.T) {
+	got, err := RenderTreeTableWithOptions(
+		scalarAppendixPlanNodes(),
+		RenderModePlan,
+		FormatCurrent,
+		WithPrintSections(PrintOrdering, PrintAggregate),
+		WithResolveScalarVarsRecursive(),
+	)
+	if err != nil {
+		t.Fatalf("RenderTreeTableWithOptions() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"Ordering(identified by ID):",
+		" 0: Key: COUNT_FINAL(COUNT()) DESC, SongGenre",
+		"Aggregates(identified by ID):",
+		" 3: Key: SongGenre",
+		"    Agg: COUNT_FINAL($v1)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RenderTreeTableWithOptions() output does not contain %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Predicates(identified by ID):") {
+		t.Fatalf("RenderTreeTableWithOptions() output contains predicates despite explicit sections:\n%s", got)
+	}
+}
+
+func TestRenderTreeTableWithConfig_PrintSections(t *testing.T) {
+	got, err := RenderTreeTableWithConfig(
+		scalarAppendixPlanNodes(),
+		RenderModePlan,
+		FormatCurrent,
+		RenderConfig{
+			PrintSections:     PrintSections{PrintOrdering, PrintAggregate},
+			ShowScalarVars:    true,
+			ResolveScalarVars: true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("RenderTreeTableWithConfig() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"Ordering(identified by ID):",
+		" 0: Key: $sort_count=COUNT_FINAL($v1) DESC, $sort_genre=$group_SongGenre",
+		"Aggregates(identified by ID):",
+		" 3: Key: $group_SongGenre'=$SongGenre",
+		"    Agg: $SongCount=COUNT_FINAL($v1)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RenderTreeTableWithConfig() output does not contain %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderTreeTableWithOptions_RawPrintSections(t *testing.T) {
+	got, err := RenderTreeTableWithOptions(
+		scalarAppendixPlanNodes(),
+		RenderModePlan,
+		FormatCurrent,
+		WithPrintSections(PrintFull),
+	)
+	if err != nil {
+		t.Fatalf("RenderTreeTableWithOptions(PrintFull) error = %v", err)
+	}
+	for _, want := range []string{
+		"Node Parameters(identified by ID):",
+		" 0: Key: $sort_count=$SongCount (DESC), $sort_genre=$group_SongGenre'",
+		" 3: Key: $group_SongGenre'=$group_SongGenre",
+		"    Agg: $SongCount=COUNT_FINAL($v1)",
+		" 6: $group_SongGenre=$SongGenre, $SongGenre=SongGenre, $v1=COUNT()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RenderTreeTableWithOptions(PrintFull) output does not contain %q:\n%s", want, got)
+		}
+	}
+
+	got, err = RenderTreeTableWithOptions(
+		scalarAppendixPlanNodes(),
+		RenderModePlan,
+		FormatCurrent,
+		WithPrintSections(PrintTyped),
+	)
+	if err != nil {
+		t.Fatalf("RenderTreeTableWithOptions(PrintTyped) error = %v", err)
+	}
+	if strings.Contains(got, "$group_SongGenre=$SongGenre") {
+		t.Fatalf("RenderTreeTableWithOptions(PrintTyped) output contains untyped scalar link:\n%s", got)
+	}
+}
+
+func TestRenderTreeTableWithOptions_PrintSectionValidation(t *testing.T) {
+	_, err := RenderTreeTableWithOptions(
+		scalarAppendixPlanNodes(),
+		RenderModePlan,
+		FormatCurrent,
+		WithPrintSections(PrintPredicates, PrintFull),
+	)
+	if err == nil {
+		t.Fatal("RenderTreeTableWithOptions() error = nil, want non-nil")
+	}
+	if got, want := err.Error(), `print section "full" cannot be combined with other sections`; got != want {
+		t.Fatalf("RenderTreeTableWithOptions() error = %q, want %q", got, want)
+	}
+
+	got, err := RenderTreeTableWithOptions(
+		scalarAppendixPlanNodes(),
+		RenderModePlan,
+		FormatCurrent,
+		WithPrintSections(),
+	)
+	if err != nil {
+		t.Fatalf("RenderTreeTableWithOptions(WithPrintSections()) error = %v", err)
+	}
+	if strings.Contains(got, "identified by ID") {
+		t.Fatalf("RenderTreeTableWithOptions(WithPrintSections()) output contains appendix:\n%s", got)
+	}
+}
+
+func TestRenderConfigPrintSectionsJSONRoundTrip(t *testing.T) {
+	b, err := json.Marshal(RenderConfig{PrintSections: PrintSections{}})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if !strings.Contains(string(b), `"printSections":[]`) {
+		t.Fatalf("json.Marshal() = %s, want printSections to preserve explicit empty slice", b)
+	}
+
+	var got RenderConfig
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if got.PrintSections == nil {
+		t.Fatal("json round trip left PrintSections nil, want explicit empty slice")
+	}
+	if len(got.PrintSections) != 0 {
+		t.Fatalf("json round trip PrintSections = %#v, want empty", got.PrintSections)
 	}
 }
 
@@ -460,6 +716,41 @@ func TestRenderTreeTableWithOptions_HangingIndent(t *testing.T) {
 	}
 	if strings.Contains(hangingLine, "|  method: Row)") {
 		t.Fatalf("hanging line = %q, want node-prefix hanging indent", hangingLine)
+	}
+}
+
+func TestRenderTreeTableWithOptions_HangingIndentNoopsWithoutWrapWidth(t *testing.T) {
+	input := loadWrappedPlan(t)
+	stats, _, err := queryplan.ExtractQueryPlan([]byte(input))
+	if err != nil {
+		t.Fatalf("Failed to extract query plan: %v", err)
+	}
+
+	planNodes := stats.GetQueryPlan().GetPlanNodes()
+	base, err := RenderTreeTable(planNodes, RenderModePlan, FormatCurrent, 0)
+	if err != nil {
+		t.Fatalf("RenderTreeTable() error = %v", err)
+	}
+
+	withOption, err := RenderTreeTableWithOptions(planNodes, RenderModePlan, FormatCurrent, WithHangingIndent())
+	if err != nil {
+		t.Fatalf("RenderTreeTableWithOptions(WithHangingIndent) error = %v", err)
+	}
+	if diff := cmp.Diff(base, withOption); diff != "" {
+		t.Fatalf("RenderTreeTableWithOptions(WithHangingIndent) mismatch without wrap width (-want +got):\n%s", diff)
+	}
+
+	withConfig, err := RenderTreeTableWithConfig(
+		planNodes,
+		RenderModePlan,
+		FormatCurrent,
+		RenderConfig{HangingIndent: true},
+	)
+	if err != nil {
+		t.Fatalf("RenderTreeTableWithConfig(HangingIndent) error = %v", err)
+	}
+	if diff := cmp.Diff(base, withConfig); diff != "" {
+		t.Fatalf("RenderTreeTableWithConfig(HangingIndent) mismatch without wrap width (-want +got):\n%s", diff)
 	}
 }
 

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -627,24 +627,29 @@ func TestRenderTreeTableWithOptions_PrintSectionValidation(t *testing.T) {
 	}
 }
 
-func TestRenderConfigPrintSectionsJSONRoundTrip(t *testing.T) {
-	b, err := json.Marshal(RenderConfig{PrintSections: PrintSections{}})
-	if err != nil {
-		t.Fatalf("json.Marshal() error = %v", err)
-	}
-	if !strings.Contains(string(b), `"printSections":[]`) {
-		t.Fatalf("json.Marshal() = %s, want printSections to preserve explicit empty slice", b)
-	}
-
+func TestRenderConfigPrintSectionsJSONInputEmptySlice(t *testing.T) {
 	var got RenderConfig
-	if err := json.Unmarshal(b, &got); err != nil {
+	if err := json.Unmarshal([]byte(`{"printSections":[]}`), &got); err != nil {
 		t.Fatalf("json.Unmarshal() error = %v", err)
 	}
 	if got.PrintSections == nil {
-		t.Fatal("json round trip left PrintSections nil, want explicit empty slice")
+		t.Fatal("json.Unmarshal() left PrintSections nil, want explicit empty slice")
 	}
 	if len(got.PrintSections) != 0 {
-		t.Fatalf("json round trip PrintSections = %#v, want empty", got.PrintSections)
+		t.Fatalf("json.Unmarshal() PrintSections = %#v, want empty", got.PrintSections)
+	}
+
+	rendered, err := RenderTreeTableWithConfig(
+		scalarAppendixPlanNodes(),
+		RenderModePlan,
+		FormatCurrent,
+		got,
+	)
+	if err != nil {
+		t.Fatalf("RenderTreeTableWithConfig() error = %v", err)
+	}
+	if strings.Contains(rendered, "identified by ID") {
+		t.Fatalf("RenderTreeTableWithConfig() output contains appendix:\n%s", rendered)
 	}
 }
 

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -410,6 +410,11 @@ func TestParsePrintSections(t *testing.T) {
 			want:  PrintSections{PrintPredicates, PrintOrdering},
 		},
 		{
+			name:  "empty means no sections",
+			input: "",
+			want:  PrintSections{},
+		},
+		{
 			name:    "unknown",
 			input:   "broken",
 			wantErr: "unknown print section: broken",

--- a/treerender/treerender.go
+++ b/treerender/treerender.go
@@ -73,6 +73,7 @@ const (
 // RenderOptions configures the optional wrapping behavior of [RenderTreeWithOptions].
 type RenderOptions[T any] struct {
 	// GetContinuationAnchor returns the node-local prefix used for hanging continuation lines.
+	// It is required when [ContinuationIndentAnchor] is selected and [WrapWidth] is positive.
 	GetContinuationAnchor func(*T) string
 	// WrapWidth sets the maximum total rendered line width. A non-positive value disables wrapping.
 	WrapWidth int
@@ -167,7 +168,8 @@ func RenderTree[T any](root *T, style Style, getText func(*T) string, getChildre
 }
 
 // RenderTreeWithOptions renders a tree with optional wrapping and continuation-indent behavior.
-// It returns an error if opts contains an invalid [ContinuationIndent].
+// It returns an error if opts contains an invalid [ContinuationIndent], or if hanging-indent
+// wrapping is requested without [RenderOptions.GetContinuationAnchor].
 func RenderTreeWithOptions[T any](
 	root *T,
 	style Style,
@@ -206,7 +208,7 @@ func resolveRenderOptions[T any](opts RenderOptions[T]) (resolvedRenderOptions[T
 	if err := validateContinuationIndent(opts.ContinuationIndent); err != nil {
 		return resolvedRenderOptions[T]{}, err
 	}
-	if opts.ContinuationIndent == ContinuationIndentAnchor && opts.GetContinuationAnchor == nil {
+	if opts.ContinuationIndent == ContinuationIndentAnchor && opts.WrapWidth > 0 && opts.GetContinuationAnchor == nil {
 		return resolvedRenderOptions[T]{}, fmt.Errorf("GetContinuationAnchor is required with ContinuationIndentAnchor")
 	}
 	resolved.continuationIndent = opts.ContinuationIndent

--- a/treerender/treerender_test.go
+++ b/treerender/treerender_test.go
@@ -418,6 +418,7 @@ func TestRenderTreeWithOptions_AnchorIndentRequiresAnchorCallback(t *testing.T) 
 		func(n *Node) string { return n.Text },
 		func(n *Node) []*Node { return n.Children },
 		RenderOptions[Node]{
+			WrapWidth:          20,
 			ContinuationIndent: ContinuationIndentAnchor,
 		},
 	)
@@ -426,6 +427,30 @@ func TestRenderTreeWithOptions_AnchorIndentRequiresAnchorCallback(t *testing.T) 
 	}
 	if got := err.Error(); !strings.Contains(got, "GetContinuationAnchor is required") {
 		t.Fatalf("RenderTreeWithOptions() error = %q, want missing anchor callback", got)
+	}
+}
+
+func TestRenderTreeWithOptions_AnchorIndentWithoutCallbackNoopsWhenWrappingDisabled(t *testing.T) {
+	t.Parallel()
+
+	root := &Node{
+		Text: "root",
+		Children: []*Node{
+			{Text: "[Input] child"},
+		},
+	}
+
+	_, err := RenderTreeWithOptions(
+		root,
+		DefaultStyle(),
+		func(n *Node) string { return n.Text },
+		func(n *Node) []*Node { return n.Children },
+		RenderOptions[Node]{
+			ContinuationIndent: ContinuationIndentAnchor,
+		},
+	)
+	if err != nil {
+		t.Fatalf("RenderTreeWithOptions() error = %v, want nil when wrapping is disabled", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Move scalar appendix parsing, validation, rendering, and scalar variable resolution into `internal/scalarappendix`.
- Keep `cmd/rendertree/impl` and `plantree/reference` as thin facades over the shared internal implementation.
- Add direct tests for the internal renderer and preserve public `plantree/reference` section types without exposing internal symbols.
- Relax `treerender` hanging-indent validation when wrapping is disabled so `WithHangingIndent` remains a no-op without wrap width.

## Validation

- `go test ./...`
- `mise x -- golangci-lint run --timeout=5m`
- `git diff --check`