### PR TITLE
docs: improve README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Spanner QueryPlan manipulation module.
 - [`lab`](./lab): Small ad hoc scripts and experiments.
 - [`plantree`](./plantree): Spanner `PlanNode` tree processing and row-building primitives.
 - [`plantree/reference`](./plantree/reference): High-level reference renderer API for Go, browser, and WebAssembly callers.
-- [`protoyaml`](./protoyaml) (internal): YAML and JSON helpers for decoding protobuf query plan data; external use is not recommended.
+- [`protoyaml`](./protoyaml) (project-internal helper): YAML and JSON helpers used by this module for decoding protobuf query plan data; external use is not recommended.
 - [`stats`](./stats): Execution statistics types and extraction helpers.
 - [`treerender`](./treerender): Generic ASCII tree renderer with wrapping support.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Spanner QueryPlan manipulation module.
 
+This is a v0 module, so breaking changes are possible across all packages before v1.
+
 ## Directory overview
 
 - [`asciitable`](./asciitable): Generic ASCII table and appendix rendering helpers.
@@ -15,7 +17,7 @@ Spanner QueryPlan manipulation module.
 - [`lab`](./lab): Small ad hoc scripts and experiments.
 - [`plantree`](./plantree): Spanner `PlanNode` tree processing and row-building primitives.
 - [`plantree/reference`](./plantree/reference): High-level reference renderer API for Go, browser, and WebAssembly callers.
-- [`protoyaml`](./protoyaml) (project-internal helper): YAML and JSON helpers used by this module for decoding protobuf query plan data; external use is not recommended.
+- [`protoyaml`](./protoyaml) (project-internal helper): YAML and JSON helpers used by this module for decoding protobuf query plan data. External use is not recommended; it is especially likely to be removed or moved behind unexported/internal helpers because it exists for internal use rather than as a supported public API.
 - [`stats`](./stats): Execution statistics types and extraction helpers.
 - [`treerender`](./treerender): Generic ASCII tree renderer with wrapping support.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # spannerplan
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/apstndb/spannerplan.svg)](https://pkg.go.dev/github.com/apstndb/spannerplan)
+
 Spanner QueryPlan manipulation module.
 
 ## Browser and WASM embedding
@@ -38,9 +40,20 @@ if (result.error) {
 console.log(result.output)
 ```
 
-## Sub-projects
+## Directory overview
 
-- [rendertree](./cmd/rendertree)
+- [`asciitable`](./asciitable): Generic ASCII table and appendix rendering helpers.
+- [`cmd/lintplan`](./cmd/lintplan): CLI for printing heuristic warnings about expensive plan operators.
+- [`cmd/rendertree`](./cmd/rendertree): CLI for rendering Spanner query plans and profiles as ASCII tables.
+- [`examples/pgexplainjson`](./examples/pgexplainjson): Example renderer for PostgreSQL `EXPLAIN (ANALYZE, FORMAT JSON)` output.
+- [`examples/wasm/render`](./examples/wasm/render): Minimal WebAssembly wrapper around the reference renderer.
+- [`internal/scalarappendix`](./internal/scalarappendix): Shared scalar appendix parsing and rendering used by CLI and reference renderers.
+- [`lab`](./lab): Small ad hoc scripts and experiments.
+- [`plantree`](./plantree): Spanner `PlanNode` tree processing and row-building primitives.
+- [`plantree/reference`](./plantree/reference): High-level reference renderer API for Go, browser, and WebAssembly callers.
+- [`protoyaml`](./protoyaml): YAML and JSON helpers for decoding protobuf query plan data.
+- [`stats`](./stats): Execution statistics types and extraction helpers.
+- [`treerender`](./treerender): Generic ASCII tree renderer with wrapping support.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 
 Spanner QueryPlan manipulation module.
 
+## Directory overview
+
+- [`asciitable`](./asciitable): Generic ASCII table and appendix rendering helpers.
+- [`cmd/lintplan`](./cmd/lintplan): CLI for printing heuristic warnings about expensive plan operators.
+- [`cmd/rendertree`](./cmd/rendertree): CLI for rendering Spanner query plans and profiles as ASCII tables.
+- [`examples/pgexplainjson`](./examples/pgexplainjson): Example renderer for PostgreSQL `EXPLAIN (ANALYZE, FORMAT JSON)` output.
+- [`examples/wasm/render`](./examples/wasm/render): Minimal WebAssembly wrapper around the reference renderer.
+- [`internal`](./internal): Internal subpackages that are not recommended for external use.
+- [`lab`](./lab): Small ad hoc scripts and experiments.
+- [`plantree`](./plantree): Spanner `PlanNode` tree processing and row-building primitives.
+- [`plantree/reference`](./plantree/reference): High-level reference renderer API for Go, browser, and WebAssembly callers.
+- [`protoyaml`](./protoyaml) (internal): YAML and JSON helpers for decoding protobuf query plan data; external use is not recommended.
+- [`stats`](./stats): Execution statistics types and extraction helpers.
+- [`treerender`](./treerender): Generic ASCII tree renderer with wrapping support.
+
 ## Browser and WASM embedding
 
 For browser-facing renderers, use `github.com/apstndb/spannerplan/plantree/reference`
@@ -39,21 +54,6 @@ if (result.error) {
 
 console.log(result.output)
 ```
-
-## Directory overview
-
-- [`asciitable`](./asciitable): Generic ASCII table and appendix rendering helpers.
-- [`cmd/lintplan`](./cmd/lintplan): CLI for printing heuristic warnings about expensive plan operators.
-- [`cmd/rendertree`](./cmd/rendertree): CLI for rendering Spanner query plans and profiles as ASCII tables.
-- [`examples/pgexplainjson`](./examples/pgexplainjson): Example renderer for PostgreSQL `EXPLAIN (ANALYZE, FORMAT JSON)` output.
-- [`examples/wasm/render`](./examples/wasm/render): Minimal WebAssembly wrapper around the reference renderer.
-- [`internal/scalarappendix`](./internal/scalarappendix): Shared scalar appendix parsing and rendering used by CLI and reference renderers.
-- [`lab`](./lab): Small ad hoc scripts and experiments.
-- [`plantree`](./plantree): Spanner `PlanNode` tree processing and row-building primitives.
-- [`plantree/reference`](./plantree/reference): High-level reference renderer API for Go, browser, and WebAssembly callers.
-- [`protoyaml`](./protoyaml): YAML and JSON helpers for decoding protobuf query plan data.
-- [`stats`](./stats): Execution statistics types and extraction helpers.
-- [`treerender`](./treerender): Generic ASCII tree renderer with wrapping support.
 
 ## Disclaimer
 

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -1,4 +1,8 @@
+# rendertree
+
 This tool render YAML or JSON representation of Cloud Spanner query plan as ascii format.
+
+## Input and modes
 
 It can read various types.
 * [QueryPlan](https://cloud.google.com/spanner/docs/reference/rest/v1/ResultSetStats?hl=en#QueryPlan)
@@ -11,6 +15,8 @@ It can read various types.
   * Output of `gcloud spanner databases execute-sql` and [execspansql](https://github.com/apstndb/execspansql)
 
 It can render both PLAN or PROFILE.
+
+## Basic usage
 
 ```
 # from file
@@ -44,6 +50,8 @@ $ gcloud spanner databases execute-sql ${DATABASE_ID} --sql="SELECT * FROM Singe
 
 Note: `--mode=PLAN` and `--mode=PROFILE` can be omitted because the default `--mode=AUTO` can detect whether the input has execution statistics or not.
 
+## Scalar appendices
+
 `rendertree` prints predicate-like scalar parameters by default. The `--print` flag can select one or more appendix sections:
 
 - `predicates` prints predicate-like scalar links such as `Condition`, `Residual Condition`, `Seek Condition`, `Search Predicate`, and `Split Range`.
@@ -55,11 +63,15 @@ Note: `--mode=PLAN` and `--mode=PROFILE` can be omitted because the default `--m
 Use a comma-separated list for focused sections, for example `--print=predicates,ordering`.
 `typed` and `full` are intentionally noisy debug dumps and cannot be combined with other sections.
 
+### Scalar variable display
+
 Semantic appendix sections hide scalar assignment variable names by default. Use `--show-vars` when
 the assignment name itself is useful, for example to inspect what `$v1` is assigned to. Use
 `--resolve-vars` to replace direct scalar variable aliases with their assigned expression in semantic
 appendix sections. `--resolve-vars-recursive` is experimental and recursively traces aliases; it is
 useful for investigation, but can produce noisier expanded expressions.
+
+### Example
 
 For example, the following query has a `WHERE` predicate, aggregation, and ordering:
 
@@ -118,6 +130,8 @@ Aggregates(identified by ID):
      Agg: COUNT()
 ```
 
+## Custom stats columns
+
 Rendered stats columns are customizable using `--custom-file` or repeatable `--custom-column` flags. `--custom-file`, `--custom-column`, and deprecated `--custom` are mutually exclusive.
 
 ```
@@ -141,6 +155,8 @@ $ cat custom.yaml
   alignment: RIGHT
   inline: ALWAYS
 ```
+
+### Inline stats
 
 `inline` field in the custom configuration and the `--inline-stats` command-line flag together control how execution statistics are rendered.
 Inline stats are particularly useful for displaying *sparse* statistics (those that only appear on a few operators) without adding many empty columns to the main table, thus improving readability.
@@ -221,6 +237,8 @@ Predicates(identified by ID):
  34: Seek Condition: (($SingerId' = $batched_SingerId) AND ($AlbumId' = $batched_AlbumId) AND ($TrackId' = $batched_TrackId))
 ```
 
+### Repeatable custom columns
+
 You can also use repeatable `--custom-column` flags. Each flag value is a single column definition in JSON or flow-style YAML, using the same schema as `--custom-file`.
 
 ```
@@ -252,9 +270,11 @@ Predicates(identified by ID):
  17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
 ```
 
+### Deprecated custom syntax
+
 The older `--custom=<name>:<template>[:<align>[:<inline_type>]]` form is still accepted for compatibility, but it is deprecated because the delimiter-based mini-language cannot represent all valid template strings robustly.
 
-## Options for narrower width
+## Narrow width output
 
 rendertree supports a compact format and wrapping for limited width environment.
 

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -1,20 +1,20 @@
 # rendertree
 
-This tool render YAML or JSON representation of Cloud Spanner query plan as ascii format.
+`rendertree` renders YAML or JSON representations of Cloud Spanner query plans as ASCII tables.
 
 ## Input and modes
 
-It can read various types.
+Supported input formats:
 * [QueryPlan](https://cloud.google.com/spanner/docs/reference/rest/v1/ResultSetStats?hl=en#QueryPlan)
-  * Can get easily by client libraries
+  * Available from client libraries:
     * [AnalyzeQuery()](https://pkg.go.dev/cloud.google.com/go/spanner#ReadOnlyTransaction.AnalyzeQuery)
     * [RowIterator.QueryPlan](https://pkg.go.dev/cloud.google.com/go/spanner#RowIterator)
 * [ResultSetStats](https://cloud.google.com/spanner/docs/reference/rest/v1/ResultSetStats?hl=en)
-  * Output of DOWNLOAD JSON in [the official query plan visualizer](https://cloud.google.com/spanner/docs/tune-query-with-visualizer?hl=en)
+  * Output from DOWNLOAD JSON in [the official query plan visualizer](https://cloud.google.com/spanner/docs/tune-query-with-visualizer?hl=en)
 * [ResultSet](https://cloud.google.com/spanner/docs/reference/rest/v1/ResultSet?hl=en)
-  * Output of `gcloud spanner databases execute-sql` and [execspansql](https://github.com/apstndb/execspansql)
+  * Output from `gcloud spanner databases execute-sql` and [execspansql](https://github.com/apstndb/execspansql)
 
-It can render both PLAN or PROFILE.
+It can render both PLAN and PROFILE inputs.
 
 ## Basic usage
 
@@ -276,7 +276,7 @@ The older `--custom=<name>:<template>[:<align>[:<inline_type>]]` form is still a
 
 ## Narrow width output
 
-rendertree supports a compact format and wrapping for limited width environment.
+`rendertree` supports compact formatting and wrapping for limited-width environments.
 
 - `--compact` enables the compact format:
   - Each level of depth in the Query Plan tree adds only one character to its indentation.


### PR DESCRIPTION
Summary:

- Add a pkg.go.dev badge to the repository README.

- Replace the terse sub-project list with a directory overview for the main packages, commands, examples, and helpers.

- Add headings to cmd/rendertree/README.md and organize related sections into a clearer hierarchy.

Validation:

- go test -v ./...

- mise x -- golangci-lint run --timeout=5m
