### PR TITLE
feat: add print appendix presets

### DIFF
--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -68,6 +68,7 @@ The `--print` flag can also select one or more low-level appendix sections:
 - `full` prints all scalar links, including unnamed links, as a raw debug dump.
 
 Use a comma-separated list for focused sections, for example `--print=predicates,ordering`.
+Preset names are standalone choices and cannot be mixed into section lists.
 `typed` and `full` are intentionally noisy debug dumps and cannot be combined with other sections.
 
 ### Scalar variable display

--- a/cmd/rendertree/README.md
+++ b/cmd/rendertree/README.md
@@ -52,7 +52,14 @@ Note: `--mode=PLAN` and `--mode=PROFILE` can be omitted because the default `--m
 
 ## Scalar appendices
 
-`rendertree` prints predicate-like scalar parameters by default. The `--print` flag can select one or more appendix sections:
+`rendertree` prints predicate-like scalar parameters by default. The `--print` flag accepts intent-based presets:
+
+- `basic` prints predicate-like scalar links. This is the default when `--print` is omitted.
+- `enhanced` prints predicates, ordering details, and aggregate details.
+- `full` prints all scalar links, including unnamed links, as a raw debug dump.
+- `none` suppresses appendix output. An explicit empty value, `--print=""`, also suppresses appendix output.
+
+The `--print` flag can also select one or more low-level appendix sections:
 
 - `predicates` prints predicate-like scalar links such as `Condition`, `Residual Condition`, `Seek Condition`, `Search Predicate`, and `Split Range`.
 - `ordering` prints ordering details from `Sort`, `Sort Limit`, `Minor Sort`, and `Minor Sort Limit` operators.

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -288,13 +288,15 @@ func parseExplainMode(s string) (explainMode, error) {
 	}
 }
 
+const printFlagUsage = "print appendix preset (basic, enhanced, full, none; empty value suppresses appendices) or comma-separated sections (predicates, ordering, aggregate, typed, full); presets are standalone; typed/full cannot be combined"
+
 func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	flagSet := flag.NewFlagSet("rendertree", flag.ContinueOnError)
 	flagSet.SetOutput(stderr)
 
 	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file (mutually exclusive with --custom and --custom-column)")
 	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
-	printSectionsStr := flagSet.String("print", "basic", "print appendix preset or sections: basic, enhanced, full, none, or comma-separated predicates, ordering, aggregate, typed, full")
+	printSectionsStr := flagSet.String("print", "basic", printFlagUsage)
 	showScalarVars := flagSet.Bool("show-vars", false, "show scalar variable assignments in semantic appendix sections")
 	resolveScalarVars := flagSet.Bool("resolve-vars", false, "EXPERIMENTAL: resolve scalar variable aliases in semantic appendix sections")
 	resolveScalarVarsRecursive := flagSet.Bool("resolve-vars-recursive", false, "EXPERIMENTAL: recursively resolve scalar variable aliases in semantic appendix sections")

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -294,7 +294,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 
 	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file (mutually exclusive with --custom and --custom-column)")
 	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
-	printSectionsStr := flagSet.String("print", "predicates", "print appendix sections: predicates, ordering, aggregate, typed, full (comma-separated; typed/full are raw debug dumps)")
+	printSectionsStr := flagSet.String("print", "predicates", "print appendix preset or sections: basic, enhanced, full, none, or comma-separated predicates, ordering, aggregate, typed, full")
 	showScalarVars := flagSet.Bool("show-vars", false, "show scalar variable assignments in semantic appendix sections")
 	resolveScalarVars := flagSet.Bool("resolve-vars", false, "EXPERIMENTAL: resolve scalar variable aliases in semantic appendix sections")
 	resolveScalarVarsRecursive := flagSet.Bool("resolve-vars-recursive", false, "EXPERIMENTAL: recursively resolve scalar variable aliases in semantic appendix sections")

--- a/cmd/rendertree/impl/impl.go
+++ b/cmd/rendertree/impl/impl.go
@@ -294,7 +294,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 
 	customFile := flagSet.String("custom-file", "", "Read custom table column definitions from a YAML file (mutually exclusive with --custom and --custom-column)")
 	mode := flagSet.String("mode", "AUTO", "PROFILE, PLAN, AUTO(ignore case)")
-	printSectionsStr := flagSet.String("print", "predicates", "print appendix preset or sections: basic, enhanced, full, none, or comma-separated predicates, ordering, aggregate, typed, full")
+	printSectionsStr := flagSet.String("print", "basic", "print appendix preset or sections: basic, enhanced, full, none, or comma-separated predicates, ordering, aggregate, typed, full")
 	showScalarVars := flagSet.Bool("show-vars", false, "show scalar variable assignments in semantic appendix sections")
 	resolveScalarVars := flagSet.Bool("resolve-vars", false, "EXPERIMENTAL: resolve scalar variable aliases in semantic appendix sections")
 	resolveScalarVarsRecursive := flagSet.Bool("resolve-vars-recursive", false, "EXPERIMENTAL: recursively resolve scalar variable aliases in semantic appendix sections")

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -721,6 +721,11 @@ func TestParsePrintSections(t *testing.T) {
 			wantErr: "unknown print preset or section: broken",
 		},
 		{
+			name:    "preset cannot be combined",
+			input:   "basic,ordering",
+			wantErr: `print preset "basic" cannot be combined with section list`,
+		},
+		{
 			name:    "duplicate",
 			input:   "predicates,predicates",
 			wantErr: "duplicate print section: predicates",

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -718,7 +718,7 @@ func TestParsePrintSections(t *testing.T) {
 		{
 			name:    "unknown",
 			input:   "broken",
-			wantErr: "unknown print preset or section: broken",
+			wantErr: `unknown print preset or section: "broken"`,
 		},
 		{
 			name:    "preset cannot be combined",
@@ -846,7 +846,7 @@ func TestRun_UsageErrors(t *testing.T) {
 		{
 			name:        "invalid print",
 			args:        []string{"-print", "broken"},
-			wantErrText: "unknown print preset or section: broken",
+			wantErrText: `unknown print preset or section: "broken"`,
 			postCheck: func(t *testing.T, stderr string, err error) {
 				t.Helper()
 				if !strings.Contains(stderr, "Invalid value for -print flag:") {

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -718,7 +718,7 @@ func TestParsePrintSections(t *testing.T) {
 		{
 			name:    "unknown",
 			input:   "broken",
-			wantErr: "unknown print section: broken",
+			wantErr: "unknown print preset or section: broken",
 		},
 		{
 			name:    "duplicate",
@@ -841,7 +841,7 @@ func TestRun_UsageErrors(t *testing.T) {
 		{
 			name:        "invalid print",
 			args:        []string{"-print", "broken"},
-			wantErrText: "unknown print section: broken",
+			wantErrText: "unknown print preset or section: broken",
 			postCheck: func(t *testing.T, stderr string, err error) {
 				t.Helper()
 				if !strings.Contains(stderr, "Invalid value for -print flag:") {

--- a/cmd/rendertree/impl/impl_test.go
+++ b/cmd/rendertree/impl/impl_test.go
@@ -691,6 +691,26 @@ func TestParsePrintSections(t *testing.T) {
 			want:  PrintSections{PrintPredicates, PrintOrdering},
 		},
 		{
+			name:  "basic preset",
+			input: "basic",
+			want:  PrintSections{PrintPredicates},
+		},
+		{
+			name:  "enhanced preset",
+			input: " Enhanced ",
+			want:  PrintSections{PrintPredicates, PrintOrdering, PrintAggregate},
+		},
+		{
+			name:  "full preset",
+			input: "full",
+			want:  PrintSections{PrintFull},
+		},
+		{
+			name:  "none preset",
+			input: "none",
+			want:  PrintSections{},
+		},
+		{
 			name:  "empty means no sections",
 			input: "",
 			want:  PrintSections{},
@@ -726,6 +746,9 @@ func TestParsePrintSections(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("parsePrintSections() error = %v", err)
+			}
+			if tt.want != nil && got == nil {
+				t.Fatal("parsePrintSections() returned nil, want non-nil explicit sections")
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("parsePrintSections() mismatch (-want +got):\n%s", diff)

--- a/internal/scalarappendix/appendix.go
+++ b/internal/scalarappendix/appendix.go
@@ -121,32 +121,40 @@ func ParseSection(s string) (Section, error) {
 // An empty string returns a non-nil empty list, which renders no appendix sections.
 func ParseSections(s string) (Sections, error) {
 	s = strings.TrimSpace(s)
+	var sections Sections
 	if s == "" {
-		return Sections{}, nil
-	}
-	if !strings.Contains(s, ",") {
+		sections = Sections{}
+	} else if !strings.Contains(s, ",") {
 		preset, presetErr := ParsePreset(s)
 		if presetErr == nil {
-			return preset.Sections()
+			var err error
+			sections, err = preset.Sections()
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			section, sectionErr := ParseSection(s)
+			if sectionErr != nil {
+				return nil, fmt.Errorf("unknown print preset or section: %s", s)
+			}
+			sections = Sections{section}
 		}
-		section, sectionErr := ParseSection(s)
-		if sectionErr == nil {
-			return Sections{section}, nil
-		}
-		return nil, fmt.Errorf("unknown print preset or section: %s", s)
-	}
+	} else {
+		for _, raw := range strings.Split(s, ",") {
+			token := strings.TrimSpace(raw)
+			if token == "" {
+				return nil, fmt.Errorf("print section must not be empty")
+			}
 
-	var sections Sections
-	for _, raw := range strings.Split(s, ",") {
-		if strings.TrimSpace(raw) == "" {
-			return nil, fmt.Errorf("print section must not be empty")
+			section, err := ParseSection(token)
+			if err != nil {
+				if _, presetErr := ParsePreset(token); presetErr == nil {
+					return nil, fmt.Errorf("print preset %q cannot be combined with section list", token)
+				}
+				return nil, err
+			}
+			sections = append(sections, section)
 		}
-
-		section, err := ParseSection(raw)
-		if err != nil {
-			return nil, err
-		}
-		sections = append(sections, section)
 	}
 
 	if err := ValidateSections(sections); err != nil {

--- a/internal/scalarappendix/appendix.go
+++ b/internal/scalarappendix/appendix.go
@@ -67,6 +67,7 @@ type Options struct {
 
 // ParsePreset parses one print preset name.
 // Valid values are "basic", "enhanced", "full", and "none" (case-insensitive).
+// Empty input is not a preset; use [ParseSections] for explicit-empty appendix semantics.
 func ParsePreset(s string) (Preset, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case string(PresetBasic):
@@ -78,7 +79,7 @@ func ParsePreset(s string) (Preset, error) {
 	case string(PresetNone):
 		return PresetNone, nil
 	default:
-		return "", fmt.Errorf("unknown print preset: %s", s)
+		return "", fmt.Errorf("unknown print preset: %q", s)
 	}
 }
 
@@ -94,7 +95,7 @@ func (p Preset) Sections() (Sections, error) {
 	case PresetNone:
 		return Sections{}, nil
 	default:
-		return nil, fmt.Errorf("unsupported print preset: %s", p)
+		return nil, fmt.Errorf("unsupported print preset: %q", p)
 	}
 }
 
@@ -135,7 +136,7 @@ func ParseSections(s string) (Sections, error) {
 		} else {
 			section, sectionErr := ParseSection(s)
 			if sectionErr != nil {
-				return nil, fmt.Errorf("unknown print preset or section: %s", s)
+				return nil, fmt.Errorf("unknown print preset or section: %q", s)
 			}
 			sections = Sections{section}
 		}

--- a/internal/scalarappendix/appendix.go
+++ b/internal/scalarappendix/appendix.go
@@ -120,14 +120,20 @@ func ParseSection(s string) (Section, error) {
 // ParseSections parses a named preset or a comma-separated print-section list.
 // An empty string returns a non-nil empty list, which renders no appendix sections.
 func ParseSections(s string) (Sections, error) {
-	if strings.TrimSpace(s) == "" {
+	s = strings.TrimSpace(s)
+	if s == "" {
 		return Sections{}, nil
 	}
 	if !strings.Contains(s, ",") {
-		preset, err := ParsePreset(s)
-		if err == nil {
+		preset, presetErr := ParsePreset(s)
+		if presetErr == nil {
 			return preset.Sections()
 		}
+		section, sectionErr := ParseSection(s)
+		if sectionErr == nil {
+			return Sections{section}, nil
+		}
+		return nil, fmt.Errorf("unknown print preset or section: %s", s)
 	}
 
 	var sections Sections

--- a/internal/scalarappendix/appendix.go
+++ b/internal/scalarappendix/appendix.go
@@ -119,7 +119,7 @@ func ParseSection(s string) (Section, error) {
 }
 
 // ParseSections parses a named preset or a comma-separated print-section list.
-// An empty string returns a non-nil empty list, which renders no appendix sections.
+// Empty or blank input returns a non-nil empty list, which renders no appendix sections.
 func ParseSections(s string) (Sections, error) {
 	s = strings.TrimSpace(s)
 	var sections Sections
@@ -141,6 +141,8 @@ func ParseSections(s string) (Sections, error) {
 			sections = Sections{section}
 		}
 	} else {
+		// Comma-separated input is section-list syntax. Unknown tokens intentionally keep
+		// the section-list error shape used before presets were added.
 		for _, raw := range strings.Split(s, ",") {
 			token := strings.TrimSpace(raw)
 			if token == "" {

--- a/internal/scalarappendix/appendix.go
+++ b/internal/scalarappendix/appendix.go
@@ -34,6 +34,20 @@ const (
 // Sections is an ordered list of appendix sections.
 type Sections []Section
 
+// Preset selects an intent-based appendix section set.
+type Preset string
+
+const (
+	// PresetBasic prints predicate-like scalar links.
+	PresetBasic Preset = "basic"
+	// PresetEnhanced prints predicate, ordering, and aggregate sections.
+	PresetEnhanced Preset = "enhanced"
+	// PresetFull prints all scalar links, including unnamed links.
+	PresetFull Preset = "full"
+	// PresetNone suppresses appendix sections.
+	PresetNone Preset = "none"
+)
+
 // Options configures appendix rendering.
 type Options struct {
 	// Sections selects appendix sections.
@@ -49,6 +63,39 @@ type Options struct {
 
 	// ResolveScalarVarsRecursive recursively resolves scalar variable aliases in semantic appendix sections.
 	ResolveScalarVarsRecursive bool
+}
+
+// ParsePreset parses one print preset name.
+// Valid values are "basic", "enhanced", "full", and "none" (case-insensitive).
+func ParsePreset(s string) (Preset, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case string(PresetBasic):
+		return PresetBasic, nil
+	case string(PresetEnhanced):
+		return PresetEnhanced, nil
+	case string(PresetFull):
+		return PresetFull, nil
+	case string(PresetNone):
+		return PresetNone, nil
+	default:
+		return "", fmt.Errorf("unknown print preset: %s", s)
+	}
+}
+
+// Sections returns the appendix sections for p.
+func (p Preset) Sections() (Sections, error) {
+	switch p {
+	case PresetBasic:
+		return Sections{SectionPredicates}, nil
+	case PresetEnhanced:
+		return Sections{SectionPredicates, SectionOrdering, SectionAggregate}, nil
+	case PresetFull:
+		return Sections{SectionFull}, nil
+	case PresetNone:
+		return Sections{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported print preset: %s", p)
+	}
 }
 
 // ParseSection parses one print-section name.
@@ -70,11 +117,17 @@ func ParseSection(s string) (Section, error) {
 	}
 }
 
-// ParseSections parses a comma-separated print-section list.
-// An empty string returns an empty list, which renders no appendix sections.
+// ParseSections parses a named preset or a comma-separated print-section list.
+// An empty string returns a non-nil empty list, which renders no appendix sections.
 func ParseSections(s string) (Sections, error) {
 	if strings.TrimSpace(s) == "" {
 		return Sections{}, nil
+	}
+	if !strings.Contains(s, ",") {
+		preset, err := ParsePreset(s)
+		if err == nil {
+			return preset.Sections()
+		}
 	}
 
 	var sections Sections

--- a/internal/scalarappendix/appendix_test.go
+++ b/internal/scalarappendix/appendix_test.go
@@ -65,7 +65,7 @@ func TestParseSections(t *testing.T) {
 		{
 			name:    "unknown",
 			input:   "broken",
-			wantErr: "unknown print section: broken",
+			wantErr: "unknown print preset or section: broken",
 		},
 		{
 			name:    "duplicate",

--- a/internal/scalarappendix/appendix_test.go
+++ b/internal/scalarappendix/appendix_test.go
@@ -28,6 +28,26 @@ func TestParseSections(t *testing.T) {
 			want:  Sections{SectionPredicates, SectionOrdering, SectionAggregate},
 		},
 		{
+			name:  "basic preset",
+			input: "basic",
+			want:  Sections{SectionPredicates},
+		},
+		{
+			name:  "enhanced preset",
+			input: " Enhanced ",
+			want:  Sections{SectionPredicates, SectionOrdering, SectionAggregate},
+		},
+		{
+			name:  "full preset",
+			input: "full",
+			want:  Sections{SectionFull},
+		},
+		{
+			name:  "none preset",
+			input: "none",
+			want:  Sections{},
+		},
+		{
 			name:  "empty means no sections",
 			input: "",
 			want:  Sections{},
@@ -73,6 +93,9 @@ func TestParseSections(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("ParseSections() error = %v", err)
+			}
+			if tt.want != nil && got == nil {
+				t.Fatal("ParseSections() returned nil, want non-nil explicit sections")
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("ParseSections() mismatch (-want +got):\n%s", diff)

--- a/internal/scalarappendix/appendix_test.go
+++ b/internal/scalarappendix/appendix_test.go
@@ -109,13 +109,54 @@ func TestParseSections(t *testing.T) {
 	}
 }
 
-func TestParsePresetEmptyIsNotPreset(t *testing.T) {
-	_, err := ParsePreset("")
-	if err == nil {
-		t.Fatal("ParsePreset() error = nil, want non-nil")
+func TestParsePreset(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Preset
+		wantErr string
+	}{
+		{
+			name:  "basic",
+			input: " BASIC ",
+			want:  PresetBasic,
+		},
+		{
+			name:    "empty is not preset",
+			input:   "",
+			wantErr: `unknown print preset: ""`,
+		},
+		{
+			name:    "unknown",
+			input:   "broken",
+			wantErr: `unknown print preset: "broken"`,
+		},
+		{
+			name:    "comma-separated list is not preset",
+			input:   "enhanced,ordering",
+			wantErr: `unknown print preset: "enhanced,ordering"`,
+		},
 	}
-	if got, want := err.Error(), `unknown print preset: ""`; got != want {
-		t.Fatalf("ParsePreset() error = %q, want %q", got, want)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePreset(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("ParsePreset() error = nil, want non-nil")
+				}
+				if got := err.Error(); got != tt.wantErr {
+					t.Fatalf("ParsePreset() error = %q, want %q", got, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePreset() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParsePreset() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/scalarappendix/appendix_test.go
+++ b/internal/scalarappendix/appendix_test.go
@@ -68,6 +68,11 @@ func TestParseSections(t *testing.T) {
 			wantErr: "unknown print preset or section: broken",
 		},
 		{
+			name:    "preset cannot be combined",
+			input:   "basic,ordering",
+			wantErr: `print preset "basic" cannot be combined with section list`,
+		},
+		{
 			name:    "duplicate",
 			input:   "predicates,predicates",
 			wantErr: "duplicate print section: predicates",

--- a/internal/scalarappendix/appendix_test.go
+++ b/internal/scalarappendix/appendix_test.go
@@ -65,7 +65,7 @@ func TestParseSections(t *testing.T) {
 		{
 			name:    "unknown",
 			input:   "broken",
-			wantErr: "unknown print preset or section: broken",
+			wantErr: `unknown print preset or section: "broken"`,
 		},
 		{
 			name:    "preset cannot be combined",
@@ -106,6 +106,16 @@ func TestParseSections(t *testing.T) {
 				t.Fatalf("ParseSections() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestParsePresetEmptyIsNotPreset(t *testing.T) {
+	_, err := ParsePreset("")
+	if err == nil {
+		t.Fatal("ParsePreset() error = nil, want non-nil")
+	}
+	if got, want := err.Error(), `unknown print preset: ""`; got != want {
+		t.Fatalf("ParsePreset() error = %q, want %q", got, want)
 	}
 }
 

--- a/plantree/reference/appendix.go
+++ b/plantree/reference/appendix.go
@@ -70,7 +70,7 @@ func ParsePrintSection(s string) (PrintSection, error) {
 }
 
 // ParsePrintSections parses a named preset or a comma-separated print-section list.
-// An empty string returns a non-nil empty list that suppresses appendices when used explicitly.
+// Empty or blank input returns a non-nil empty list that suppresses appendices when used explicitly.
 func ParsePrintSections(s string) (PrintSections, error) {
 	sections, err := scalarappendix.ParseSections(s)
 	if err != nil {

--- a/plantree/reference/appendix.go
+++ b/plantree/reference/appendix.go
@@ -24,6 +24,44 @@ const (
 // PrintSections is an ordered list of appendix sections.
 type PrintSections []PrintSection
 
+// PrintPreset selects an intent-based appendix section set.
+type PrintPreset string
+
+const (
+	// PrintPresetBasic prints predicate-like scalar links.
+	PrintPresetBasic PrintPreset = "basic"
+	// PrintPresetEnhanced prints predicate, ordering, and aggregate sections.
+	PrintPresetEnhanced PrintPreset = "enhanced"
+	// PrintPresetFull prints all scalar links, including unnamed links.
+	PrintPresetFull PrintPreset = "full"
+	// PrintPresetNone suppresses appendix sections.
+	PrintPresetNone PrintPreset = "none"
+)
+
+// NewPrintSections returns a config-ready print section pointer.
+// Passing no sections returns an explicit empty section list that suppresses appendices.
+// Use nil to keep the default [PrintPresetBasic] behavior in [RenderConfig].
+func NewPrintSections(sections ...PrintSection) *PrintSections {
+	copied := append(PrintSections{}, sections...)
+	return &copied
+}
+
+// ParsePrintPreset parses one print preset name.
+// Valid values are "basic", "enhanced", "full", and "none" (case-insensitive).
+func ParsePrintPreset(s string) (PrintPreset, error) {
+	preset, err := scalarappendix.ParsePreset(s)
+	return PrintPreset(preset), err
+}
+
+// Sections returns the appendix sections for p.
+func (p PrintPreset) Sections() (PrintSections, error) {
+	sections, err := scalarappendix.Preset(p).Sections()
+	if err != nil {
+		return nil, err
+	}
+	return printSectionsFromScalarAppendix(sections), nil
+}
+
 // ParsePrintSection parses one print-section name.
 // Valid values are "predicates", "ordering", "aggregate", "typed", and "full" (case-insensitive).
 func ParsePrintSection(s string) (PrintSection, error) {
@@ -31,7 +69,8 @@ func ParsePrintSection(s string) (PrintSection, error) {
 	return PrintSection(section), err
 }
 
-// ParsePrintSections parses a comma-separated print-section list.
+// ParsePrintSections parses a named preset or a comma-separated print-section list.
+// An empty string returns a non-nil empty list that suppresses appendices when used explicitly.
 func ParsePrintSections(s string) (PrintSections, error) {
 	sections, err := scalarappendix.ParseSections(s)
 	if err != nil {

--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -66,6 +66,9 @@ type RenderConfig struct {
 	// A nil pointer uses the default [PrintPredicates] section.
 	// In JSON config, omit this field or set it to null to use the default; set
 	// it to [] to print no appendix sections.
+	// Use [NewPrintSections] with [PrintPreset.Sections] when converting preset
+	// names such as [PrintPresetBasic], [PrintPresetEnhanced], [PrintPresetFull],
+	// and [PrintPresetNone] into config values.
 	PrintSections *PrintSections `json:"printSections,omitempty"`
 
 	// ShowScalarVars prints scalar assignment variable names in semantic appendix sections.

--- a/plantree/reference/reference.go
+++ b/plantree/reference/reference.go
@@ -66,9 +66,16 @@ type RenderConfig struct {
 	// A nil pointer uses the default [PrintPredicates] section.
 	// In JSON config, omit this field or set it to null to use the default; set
 	// it to [] to print no appendix sections.
-	// Use [NewPrintSections] with [PrintPreset.Sections] when converting preset
-	// names such as [PrintPresetBasic], [PrintPresetEnhanced], [PrintPresetFull],
-	// and [PrintPresetNone] into config values.
+	// When converting preset names such as [PrintPresetBasic], [PrintPresetEnhanced],
+	// [PrintPresetFull], and [PrintPresetNone] into config values, handle the error
+	// from [PrintPreset.Sections] and pass the result to [NewPrintSections] with
+	// variadic expansion:
+	//
+	//	sections, err := preset.Sections()
+	//	if err != nil {
+	//		return err
+	//	}
+	//	cfg.PrintSections = NewPrintSections(sections...)
 	PrintSections *PrintSections `json:"printSections,omitempty"`
 
 	// ShowScalarVars prints scalar assignment variable names in semantic appendix sections.

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -440,6 +440,11 @@ func TestParsePrintSections(t *testing.T) {
 			wantErr: "unknown print preset or section: broken",
 		},
 		{
+			name:    "preset cannot be combined",
+			input:   "basic,ordering",
+			wantErr: `print preset "basic" cannot be combined with section list`,
+		},
+		{
 			name:    "duplicate",
 			input:   "predicates,predicates",
 			wantErr: "duplicate print section: predicates",

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -410,6 +410,26 @@ func TestParsePrintSections(t *testing.T) {
 			want:  PrintSections{PrintPredicates, PrintOrdering},
 		},
 		{
+			name:  "basic preset",
+			input: "basic",
+			want:  PrintSections{PrintPredicates},
+		},
+		{
+			name:  "enhanced preset",
+			input: " Enhanced ",
+			want:  PrintSections{PrintPredicates, PrintOrdering, PrintAggregate},
+		},
+		{
+			name:  "full preset",
+			input: "full",
+			want:  PrintSections{PrintFull},
+		},
+		{
+			name:  "none preset",
+			input: "none",
+			want:  PrintSections{},
+		},
+		{
 			name:  "empty means no sections",
 			input: "",
 			want:  PrintSections{},
@@ -446,8 +466,43 @@ func TestParsePrintSections(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ParsePrintSections() error = %v", err)
 			}
+			if tt.want != nil && got == nil {
+				t.Fatal("ParsePrintSections() returned nil, want non-nil explicit sections")
+			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("ParsePrintSections() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPrintPresetSections(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  PrintSections
+	}{
+		{name: "basic", input: "basic", want: PrintSections{PrintPredicates}},
+		{name: "enhanced", input: "enhanced", want: PrintSections{PrintPredicates, PrintOrdering, PrintAggregate}},
+		{name: "full", input: "full", want: PrintSections{PrintFull}},
+		{name: "none", input: "none", want: PrintSections{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preset, err := ParsePrintPreset(tt.input)
+			if err != nil {
+				t.Fatalf("ParsePrintPreset() error = %v", err)
+			}
+			got, err := preset.Sections()
+			if err != nil {
+				t.Fatalf("PrintPreset.Sections() error = %v", err)
+			}
+			if got == nil {
+				t.Fatal("PrintPreset.Sections() returned nil, want non-nil sections")
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("PrintPreset.Sections() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -541,7 +596,7 @@ func TestRenderTreeTableWithConfig_PrintSections(t *testing.T) {
 		RenderModePlan,
 		FormatCurrent,
 		RenderConfig{
-			PrintSections:     printSectionsPtr(PrintOrdering, PrintAggregate),
+			PrintSections:     NewPrintSections(PrintOrdering, PrintAggregate),
 			ShowScalarVars:    true,
 			ResolveScalarVars: true,
 		},
@@ -627,13 +682,8 @@ func TestRenderTreeTableWithOptions_PrintSectionValidation(t *testing.T) {
 	}
 }
 
-func printSectionsPtr(sections ...PrintSection) *PrintSections {
-	copied := append(PrintSections{}, sections...)
-	return &copied
-}
-
 func TestRenderConfigPrintSectionsJSONRoundTripEmptySlice(t *testing.T) {
-	b, err := json.Marshal(RenderConfig{PrintSections: printSectionsPtr()})
+	b, err := json.Marshal(RenderConfig{PrintSections: NewPrintSections()})
 	if err != nil {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -437,7 +437,7 @@ func TestParsePrintSections(t *testing.T) {
 		{
 			name:    "unknown",
 			input:   "broken",
-			wantErr: "unknown print section: broken",
+			wantErr: "unknown print preset or section: broken",
 		},
 		{
 			name:    "duplicate",

--- a/plantree/reference/reference_test.go
+++ b/plantree/reference/reference_test.go
@@ -437,7 +437,7 @@ func TestParsePrintSections(t *testing.T) {
 		{
 			name:    "unknown",
 			input:   "broken",
-			wantErr: "unknown print preset or section: broken",
+			wantErr: `unknown print preset or section: "broken"`,
 		},
 		{
 			name:    "preset cannot be combined",


### PR DESCRIPTION
## Summary

- Add intent-based print presets for scalar appendices: `basic`, `enhanced`, `full`, and `none`.
- Let `ParsePrintSections` and `rendertree --print` accept those presets while preserving comma-separated low-level section names.
- Add `reference.NewPrintSections` so config bridges can preserve the nil/default versus explicit-empty distinction for `RenderConfig.PrintSections`.
- Document the presets in `cmd/rendertree/README.md`.

## Issue handling

- Closes #43 by exposing shared preset names and parser behavior instead of leaving downstream UIs to invent their own meanings.
- Closes #44 by documenting and testing that empty string parsing returns a non-nil empty section list, and by adding a helper for explicit empty config values.

## Verification

- `go test ./internal/scalarappendix ./plantree/reference ./cmd/rendertree/impl`
- `go test ./...`
- `mise x -- golangci-lint run --timeout=5m`
- `git diff --check`
- `review-router`: `copilot-gpt-5.4`, `gemini-3.1-pro-preview`, `codex-gpt-5.4`
