### PR TITLE
chore: raise Gemini review threshold

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,2 @@
+code_review:
+  comment_severity_threshold: HIGH


### PR DESCRIPTION
## Summary
- Add .gemini/config.yaml for Gemini Code Assist on GitHub.
- Set code_review.comment_severity_threshold to HIGH so low/medium severity review comments are suppressed.

## Validation
- git diff --check
- ruby -e 'require "yaml"; abort unless YAML.load_file(".gemini/config.yaml").dig("code_review", "comment_severity_threshold") == "HIGH"'

Reference: https://developers.google.com/gemini-code-assist/docs/customize-repo-review