### PR TITLE
Expose stable error identity for plan validation failures

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,34 @@
+package spannerplan_test
+
+import (
+	"errors"
+	"fmt"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+
+	"github.com/apstndb/spannerplan"
+)
+
+// ExampleNew_invalidPlan shows how to detect a malformed plan without pinning
+// the error message text: errors.Is against ErrInvalidPlan matches any
+// validation failure, and errors.As exposes the structured *ValidationError.
+func ExampleNew_invalidPlan() {
+	// A child link references a node index that does not exist.
+	_, err := spannerplan.New([]*sppb.PlanNode{
+		{Index: 0, ChildLinks: []*sppb.PlanNode_ChildLink{{ChildIndex: 99}}},
+		{Index: 1},
+	})
+
+	fmt.Println("is ErrInvalidPlan:", errors.Is(err, spannerplan.ErrInvalidPlan))
+	fmt.Println("is ErrChildLinkIndexOutOfRange:", errors.Is(err, spannerplan.ErrChildLinkIndexOutOfRange))
+
+	var verr *spannerplan.ValidationError
+	if errors.As(err, &verr) {
+		fmt.Printf("node %d, child link %d\n", verr.NodeIndex, verr.ChildIndex)
+	}
+
+	// Output:
+	// is ErrInvalidPlan: true
+	// is ErrChildLinkIndexOutOfRange: true
+	// node 0, child link 0
+}

--- a/queryplan.go
+++ b/queryplan.go
@@ -54,7 +54,7 @@ var (
 type ValidationError struct {
 	// Kind is the category sentinel for this failure, e.g.
 	// ErrChildLinkIndexOutOfRange. It is always one of the exported
-	// Err* sentinels and always satisfies errors.Is against ErrInvalidPlan.
+	// Err* sentinels; the ValidationError itself also wraps ErrInvalidPlan.
 	Kind error
 	// NodeIndex is the plan-node index (equivalently, slice position, which
 	// New requires to match) involved in the failure, or -1 when no single

--- a/queryplan.go
+++ b/queryplan.go
@@ -17,11 +17,73 @@ type QueryPlan struct {
 	parentLinksMap map[int32][]ResolvedParentLink
 }
 
-var ErrEmptyPlanNodes = errors.New("spannerplan: planNodes cannot be empty")
-var ErrNilPlanNode = errors.New("spannerplan: planNode cannot be nil")
-var ErrPlanNodeIndexMismatch = errors.New("spannerplan: planNode index must match slice position")
-var ErrNilChildLink = errors.New("spannerplan: childLink cannot be nil")
-var ErrChildLinkIndexOutOfRange = errors.New("spannerplan: childLink childIndex out of range")
+// ErrInvalidPlan is the stable sentinel identifying any plan-validation
+// failure returned by New. Every validation error wraps it, so consumers can
+// detect a malformed plan with errors.Is(err, ErrInvalidPlan) regardless of
+// the specific cause or the exact message wording, which is not guaranteed to
+// remain stable.
+var ErrInvalidPlan = errors.New("spannerplan: invalid plan")
+
+// Category sentinels identify the specific kind of validation failure. Each is
+// reported through a *ValidationError (see New) whose Kind field is set to one
+// of these values and which also wraps ErrInvalidPlan. Match them with
+// errors.Is; prefer ErrInvalidPlan when any validation failure should be
+// treated the same way.
+var (
+	ErrEmptyPlanNodes           = errors.New("spannerplan: planNodes cannot be empty")
+	ErrNilPlanNode              = errors.New("spannerplan: planNode cannot be nil")
+	ErrPlanNodeIndexMismatch    = errors.New("spannerplan: planNode index must match slice position")
+	ErrNilChildLink             = errors.New("spannerplan: childLink cannot be nil")
+	ErrChildLinkIndexOutOfRange = errors.New("spannerplan: childLink childIndex out of range")
+)
+
+// ValidationError is returned by New (and any other constructor that validates
+// its input) when a plan fails validation. It provides a stable, machine-
+// readable identity for the failure so consumers can branch on it without
+// pinning message text.
+//
+// Both errors.Is and errors.As work:
+//
+//   - errors.Is(err, spannerplan.ErrInvalidPlan) matches any validation failure.
+//   - errors.Is(err, spannerplan.ErrChildLinkIndexOutOfRange) (and the other
+//     category sentinels) matches a specific failure kind.
+//   - errors.As(err, &verr) exposes the structured fields below.
+//
+// The Error string is preserved for humans but is not part of the stable API;
+// use the sentinels or the fields instead.
+type ValidationError struct {
+	// Kind is the category sentinel for this failure, e.g.
+	// ErrChildLinkIndexOutOfRange. It is always one of the exported
+	// Err* sentinels and always satisfies errors.Is against ErrInvalidPlan.
+	Kind error
+	// NodeIndex is the plan-node index (equivalently, slice position, which
+	// New requires to match) involved in the failure, or -1 when no single
+	// node applies (e.g. an empty slice).
+	NodeIndex int
+	// ChildIndex is the position within the parent node's ChildLinks slice
+	// involved in the failure, or -1 when the failure is not about a specific
+	// child link.
+	ChildIndex int
+	// err carries the full formatted message and wraps Kind, preserving the
+	// historical error text and errors.Is behavior for the category sentinel.
+	err error
+}
+
+// Error returns the full human-readable message. The exact wording is not part
+// of the stable API and may change; match on ErrInvalidPlan, the category
+// sentinels, or the struct fields instead.
+func (e *ValidationError) Error() string { return e.err.Error() }
+
+// Unwrap reports both ErrInvalidPlan and the wrapped category error, so that
+// errors.Is matches ErrInvalidPlan and every specific sentinel.
+func (e *ValidationError) Unwrap() []error { return []error{ErrInvalidPlan, e.err} }
+
+// newValidationError builds a *ValidationError from a category sentinel and the
+// fully formatted error (which itself wraps the sentinel to preserve message
+// text and errors.Is behavior).
+func newValidationError(kind error, nodeIndex, childIndex int, err error) *ValidationError {
+	return &ValidationError{Kind: kind, NodeIndex: nodeIndex, ChildIndex: childIndex, err: err}
+}
 
 // New constructs a QueryPlan from sppb.QueryPlan.PlanNodes.
 //
@@ -30,17 +92,22 @@ var ErrChildLinkIndexOutOfRange = errors.New("spannerplan: childLink childIndex 
 // position in the slice, as documented by the Spanner protobuf contract.
 // Arbitrary or reordered PlanNode slices are not supported and will return
 // an error.
+//
+// On validation failure it returns a *ValidationError that wraps ErrInvalidPlan
+// and a category sentinel; see ValidationError.
 func New(planNodes []*sppb.PlanNode) (*QueryPlan, error) {
 	if len(planNodes) == 0 {
-		return nil, ErrEmptyPlanNodes
+		return nil, newValidationError(ErrEmptyPlanNodes, -1, -1, ErrEmptyPlanNodes)
 	}
 
 	for i, planNode := range planNodes {
 		if planNode == nil {
-			return nil, fmt.Errorf("%w: at slice position %d", ErrNilPlanNode, i)
+			return nil, newValidationError(ErrNilPlanNode, i, -1,
+				fmt.Errorf("%w: at slice position %d", ErrNilPlanNode, i))
 		}
 		if planNode.GetIndex() != int32(i) {
-			return nil, fmt.Errorf("%w: at slice position %d expected index %d, got %d", ErrPlanNodeIndexMismatch, i, i, planNode.GetIndex())
+			return nil, newValidationError(ErrPlanNodeIndexMismatch, i, -1,
+				fmt.Errorf("%w: at slice position %d expected index %d, got %d", ErrPlanNodeIndexMismatch, i, i, planNode.GetIndex()))
 		}
 	}
 
@@ -49,11 +116,13 @@ func New(planNodes []*sppb.PlanNode) (*QueryPlan, error) {
 	for _, planNode := range planNodes {
 		for j, childLink := range planNode.GetChildLinks() {
 			if childLink == nil {
-				return nil, fmt.Errorf("%w: parent node %d childLinks[%d]", ErrNilChildLink, planNode.GetIndex(), j)
+				return nil, newValidationError(ErrNilChildLink, int(planNode.GetIndex()), j,
+					fmt.Errorf("%w: parent node %d childLinks[%d]", ErrNilChildLink, planNode.GetIndex(), j))
 			}
 			childIndex := childLink.GetChildIndex()
 			if childIndex < 0 || childIndex >= int32(len(planNodes)) {
-				return nil, fmt.Errorf("%w: parent node %d childLinks[%d] has childIndex %d, len(planNodes)=%d", ErrChildLinkIndexOutOfRange, planNode.GetIndex(), j, childIndex, len(planNodes))
+				return nil, newValidationError(ErrChildLinkIndexOutOfRange, int(planNode.GetIndex()), j,
+					fmt.Errorf("%w: parent node %d childLinks[%d] has childIndex %d, len(planNodes)=%d", ErrChildLinkIndexOutOfRange, planNode.GetIndex(), j, childIndex, len(planNodes)))
 			}
 			parentMap[childIndex] = planNode.GetIndex()
 			parentLinksMap[childIndex] = append(parentLinksMap[childIndex], ResolvedParentLink{
@@ -210,8 +279,10 @@ func ParseTargetMetadataFormat(s string) (TargetMetadataFormat, error) {
 	}
 }
 
-type KnownFlagFormat int64
-type FullScanFormat = KnownFlagFormat
+type (
+	KnownFlagFormat int64
+	FullScanFormat  = KnownFlagFormat
+)
 
 const (
 	// KnownFlagFormatRaw prints known boolean flag metadata as is.

--- a/queryplan_test.go
+++ b/queryplan_test.go
@@ -86,6 +86,101 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNewValidationError(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          []*sppb.PlanNode
+		wantKind       error
+		wantNodeIndex  int
+		wantChildIndex int
+		wantMessage    string
+	}{
+		{
+			name:           "empty",
+			input:          nil,
+			wantKind:       ErrEmptyPlanNodes,
+			wantNodeIndex:  -1,
+			wantChildIndex: -1,
+			wantMessage:    "spannerplan: planNodes cannot be empty",
+		},
+		{
+			name:           "nil node",
+			input:          []*sppb.PlanNode{nil},
+			wantKind:       ErrNilPlanNode,
+			wantNodeIndex:  0,
+			wantChildIndex: -1,
+			wantMessage:    "spannerplan: planNode cannot be nil: at slice position 0",
+		},
+		{
+			name:           "index mismatch",
+			input:          []*sppb.PlanNode{{Index: 1}},
+			wantKind:       ErrPlanNodeIndexMismatch,
+			wantNodeIndex:  0,
+			wantChildIndex: -1,
+			wantMessage:    "spannerplan: planNode index must match slice position: at slice position 0 expected index 0, got 1",
+		},
+		{
+			name:           "nil child link",
+			input:          []*sppb.PlanNode{{Index: 0, ChildLinks: []*sppb.PlanNode_ChildLink{nil}}},
+			wantKind:       ErrNilChildLink,
+			wantNodeIndex:  0,
+			wantChildIndex: 0,
+			wantMessage:    "spannerplan: childLink cannot be nil: parent node 0 childLinks[0]",
+		},
+		{
+			name: "child link index out of range",
+			input: []*sppb.PlanNode{
+				{Index: 0, ChildLinks: []*sppb.PlanNode_ChildLink{{ChildIndex: 99}}},
+				{Index: 1},
+			},
+			wantKind:       ErrChildLinkIndexOutOfRange,
+			wantNodeIndex:  0,
+			wantChildIndex: 0,
+			// This exact text is pinned by downstream golden tests
+			// (e.g. spanner-mycli). It must not change.
+			wantMessage: "spannerplan: childLink childIndex out of range: parent node 0 childLinks[0] has childIndex 99, len(planNodes)=2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.input)
+			if err == nil {
+				t.Fatal("New() error = nil, want error")
+			}
+
+			// Umbrella sentinel matches every validation failure.
+			if !errors.Is(err, ErrInvalidPlan) {
+				t.Errorf("errors.Is(err, ErrInvalidPlan) = false, want true (err = %v)", err)
+			}
+			// The specific category sentinel matches.
+			if !errors.Is(err, tt.wantKind) {
+				t.Errorf("errors.Is(err, %v) = false, want true (err = %v)", tt.wantKind, err)
+			}
+
+			// The typed error exposes structured fields.
+			var verr *ValidationError
+			if !errors.As(err, &verr) {
+				t.Fatalf("errors.As(err, *ValidationError) = false, want true (err = %v)", err)
+			}
+			if verr.Kind != tt.wantKind {
+				t.Errorf("verr.Kind = %v, want %v", verr.Kind, tt.wantKind)
+			}
+			if verr.NodeIndex != tt.wantNodeIndex {
+				t.Errorf("verr.NodeIndex = %d, want %d", verr.NodeIndex, tt.wantNodeIndex)
+			}
+			if verr.ChildIndex != tt.wantChildIndex {
+				t.Errorf("verr.ChildIndex = %d, want %d", verr.ChildIndex, tt.wantChildIndex)
+			}
+
+			// Message text is preserved exactly for downstream consumers.
+			if got := err.Error(); got != tt.wantMessage {
+				t.Errorf("err.Error() = %q, want %q", got, tt.wantMessage)
+			}
+		})
+	}
+}
+
 func TestHasStats(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Motivation

`spannerplan.New` validates the plan-node slice and, until now, exposed only per-category sentinels and free-form message text as its stable surface. Downstream consumers (e.g. spanner-mycli's `SHOW PLAN NODE` degraded path, apstndb/spanner-mycli#754) pin the full message string as a golden value because that was the only reliable-ish identity. That makes any rewording of a validation message a breaking change for consumers even when nothing behaviorally changed.

Fixes #48.

## API added

- `var ErrInvalidPlan` — umbrella sentinel wrapped by **every** validation failure from `New`. `errors.Is(err, spannerplan.ErrInvalidPlan)` matches any malformed plan regardless of cause or wording.
- `type ValidationError struct { Kind error; NodeIndex int; ChildIndex int; ... }` — typed error returned by `New` on validation failure. `Kind` is the category sentinel; `NodeIndex`/`ChildIndex` locate the failure (`-1` when not applicable). `Unwrap() []error` returns both `ErrInvalidPlan` and the wrapped category error, so `errors.Is`/`errors.As` both work.
- The existing category sentinels (`ErrEmptyPlanNodes`, `ErrNilPlanNode`, `ErrPlanNodeIndexMismatch`, `ErrNilChildLink`, `ErrChildLinkIndexOutOfRange`) are unchanged and still match via `errors.Is`.

## Design notes

The repo already had fine-grained sentinels, so rather than replace them I added the umbrella `ErrInvalidPlan` plus a structured type that wraps both. `New` now returns `*ValidationError` whose internal error is the *same* `fmt.Errorf` value produced before, so message text is byte-for-byte identical. This satisfies the issue's "preferred" shape (typed error + sentinel) without churning the existing sentinel API.

## Compatibility

- **Message text unchanged.** All existing error strings are preserved exactly; the downstream golden `spannerplan: childLink childIndex out of range: parent node 0 childLinks[0] has childIndex 99, len(planNodes)=2` is asserted in a new test.
- `errors.Is`/`errors.As` are now supported for both the umbrella sentinel and structured fields.
- Per the v0 convention this is a patch-level, additive change.

## Usage

```go
_, err := spannerplan.New(planNodes)
if errors.Is(err, spannerplan.ErrInvalidPlan) {
    // any malformed plan — no need to pin message text
    var verr *spannerplan.ValidationError
    if errors.As(err, &verr) {
        log.Printf("invalid plan: kind=%v node=%d child=%d", verr.Kind, verr.NodeIndex, verr.ChildIndex)
    }
}
```

## Validation

- `go test ./...` passes (new table-driven `TestNewValidationError` covers `errors.Is`/`errors.As` and message-text preservation across every validation path; runnable `ExampleNew_invalidPlan` added).
- `golangci-lint run` reports 0 issues; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRx8J3m4aexPMYDSMNY1Zs
