### PR TITLE
docs: add ECOSYSTEM.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 .tmp/
 *.code-workspace
+/genexpected

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,0 +1,46 @@
+# Spanner Query Plan Ecosystem
+
+This document defines how the repositories that render Google Cloud Spanner
+query plans relate to each other, and the rules that keep them consistent.
+
+## Repositories and roles
+
+| Repo | Role |
+|---|---|
+| [spannerplan](https://github.com/apstndb/spannerplan) (Go) | Ecosystem semantic reference: plan parsing, tree building, text rendering. Golden-output generator for ports. Pure Go — no CGO/Rust/WASM requirements. |
+| [spannerplan-rs](https://github.com/apstndb/spannerplan-rs) (Rust) | Distribution core for non-Go ecosystems (C FFI, browser WASM, GitHub-Release JS tarballs). Follows the Go reference via byte-for-byte parity tests and never forks rendering semantics; "canonical" claims in its docs are scoped to that repository's internals. |
+| [spannerplanviz](https://github.com/apstndb/spannerplanviz) (Go) | Diagram source generator (Mermaid source, and DOT source via the `dot` package) plus native Graphviz rasterization for CLI use. |
+| [rendertree-web](https://github.com/apstndb/rendertree-web) | Product UI (GitHub Pages). Thin composition layer over the libraries; bundle size and safe rendering of untrusted plans are first-class requirements. |
+
+## Design principle
+
+Rendering pipelines produce text (ASCII table, Mermaid source, DOT source).
+Rasterization happens at the edge: natively in CLIs, and in the browser via
+JS/WASM renderers (the mermaid npm package, @hpcc-js/wasm-graphviz). Do not
+embed a Graphviz runtime into WASM binaries.
+
+## Governance
+
+- Any rendering-semantics change lands first in the Go reference
+  (spannerplan) with regenerated goldens; the Rust port follows in the same
+  release train. Parity CI must be green on both sides before either
+  releases.
+- Required parity CI pins the release train. Scheduled canaries against
+  `latest`/`main` are non-blocking and report drift via issues.
+- Versioning is v0 semver: breaking changes bump minor; everything else,
+  including new public APIs, bumps patch. Rendering output changes are
+  breaking events for downstream golden tests even when the API is
+  unchanged.
+- Release checklist for spannerplan/spannerplanviz: before tagging, check
+  downstream pins and golden suites (spanner-mycli, spanner-cli,
+  rendertree-web, spannerplan-rs).
+
+## Compatibility matrix
+
+As of 2026-07-08:
+
+| Consumer | Validated against |
+|---|---|
+| spannerplanviz v0.9.1 | spannerplan v0.1.11 |
+| rendertree-web (rolling) | spannerplan v0.1.11, spannerplanviz v0.9.1 |
+| spannerplan-rs v0.1.0-alpha.1 | spannerplan `cmd/rendertree` v0.1.11 (parity CI) |

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -41,6 +41,6 @@ As of 2026-07-08:
 
 | Consumer | Validated against |
 |---|---|
-| spannerplanviz v0.9.1 | spannerplan v0.1.11 |
-| rendertree-web (rolling) | spannerplan v0.1.11, spannerplanviz v0.9.1 |
-| spannerplan-rs v0.1.0-alpha.1 | spannerplan `cmd/rendertree` v0.1.11 (parity CI) |
+| spannerplanviz v0.9.2 | spannerplan v0.2.0 |
+| rendertree-web (rolling) | spannerplan v0.2.0, spannerplanviz v0.9.2 |
+| spannerplan-rs (main, post-v0.1.0-alpha.1) | spannerplan `cmd/rendertree` v0.2.0 (parity CI) |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Spanner QueryPlan manipulation module.
 
 This is a v0 module, so breaking changes are possible across all packages before v1.
 
+See [ECOSYSTEM.md](ECOSYSTEM.md) for how this module relates to spannerplan-rs, spannerplanviz, and rendertree-web.
+
 ## Directory overview
 
 - [`asciitable`](./asciitable): Generic ASCII table and appendix rendering helpers.


### PR DESCRIPTION
## Summary
- Add ECOSYSTEM.md documenting how spannerplan relates to spannerplan-rs, spannerplanviz, and rendertree-web (roles, design principle, governance, and a compatibility matrix).
- Add a README pointer to ECOSYSTEM.md near the top.
- Ignore the locally built `genexpected` binary via `.gitignore` (the binary itself is not committed).

## Test plan
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g