### PR TITLE
Adopt github.com/apstndb/protoyaml and freeze internal package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ See [ECOSYSTEM.md](ECOSYSTEM.md) for how this module relates to spannerplan-rs, 
 - [`lab`](./lab): Small ad hoc scripts and experiments.
 - [`plantree`](./plantree): Spanner `PlanNode` tree processing and row-building primitives.
 - [`plantree/reference`](./plantree/reference): High-level reference renderer API for Go, browser, and WebAssembly callers.
-- [`protoyaml`](./protoyaml) (project-internal helper): YAML and JSON helpers used by this module for decoding protobuf query plan data. External use is not recommended; it is especially likely to be removed or moved behind unexported/internal helpers because it exists for internal use rather than as a supported public API.
+- [`protoyaml`](./protoyaml) (**deprecated, frozen**): YAML and JSON helpers formerly used by this module for decoding protobuf query plan data. It is frozen for downstream compatibility (spanner-mycli pins its exact `Marshal` output) and will be removed in v0.3.0. New code should use [`github.com/apstndb/protoyaml`](https://github.com/apstndb/protoyaml), the canonical protojson-over-YAML mapping.
 - [`stats`](./stats): Execution statistics types and extraction helpers.
 - [`treerender`](./treerender): Generic ASCII tree renderer with wrapping support.
 

--- a/extract.go
+++ b/extract.go
@@ -6,7 +6,7 @@ import (
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 
-	"github.com/apstndb/spannerplan/protoyaml"
+	"github.com/apstndb/protoyaml"
 )
 
 func ExtractQueryPlan(b []byte) (*sppb.ResultSetStats, *sppb.StructType, error) {

--- a/extract_test.go
+++ b/extract_test.go
@@ -7,7 +7,7 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/goccy/go-yaml"
 
-	"github.com/apstndb/spannerplan/protoyaml"
+	"github.com/apstndb/protoyaml"
 )
 
 func extractQueryPlanLegacy(b []byte) (*sppb.ResultSetStats, *sppb.StructType, error) {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/spanner v1.48.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
 	github.com/apstndb/go-tabwrap v0.1.3
+	github.com/apstndb/protoyaml v0.1.0
 	github.com/goccy/go-yaml v1.17.1
 	github.com/google/go-cmp v0.5.9
 	github.com/olekukonko/tablewriter v1.0.9

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/apstndb/go-tabwrap v0.1.3 h1:5lO2M7Zl5NOus4cve0tu58j3txnNRAEd9MAsFitDCQw=
 github.com/apstndb/go-tabwrap v0.1.3/go.mod h1:duMNZZhNjqj/VXR2AXJN1MWko2RyIytSP1NJyhMmUV4=
+github.com/apstndb/protoyaml v0.1.0 h1:xbps9Yly1rciJhLOFdA+KLIdEpEcIaTCboFB3QtUMKI=
+github.com/apstndb/protoyaml v0.1.0/go.mod h1:bsZCSj3nYZKfLiKRogOxuUjlURUOJpBb+G5f1b3g5Fc=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=

--- a/protoyaml/protoyaml.go
+++ b/protoyaml/protoyaml.go
@@ -1,3 +1,18 @@
+// Package protoyaml is a frozen, internal helper for decoding protobuf query
+// plan data as YAML/JSON. It is retained only for downstream compatibility:
+// spanner-mycli pins the exact bytes produced by Marshal, so the output format
+// must not change.
+//
+// The Marshal output format was never a designed artifact. It is an accident of
+// reflection-based encoding (goccy/go-yaml over the protobuf message via
+// UseJSONMarshaler) rather than a deliberate, canonical mapping. New code should
+// use github.com/apstndb/protoyaml, which implements the canonical
+// protojson-over-YAML mapping.
+//
+// This package will be removed in v0.3.0 once spanner-mycli has migrated.
+//
+// Deprecated: Use github.com/apstndb/protoyaml instead. This package is frozen
+// for downstream compatibility and will be removed in v0.3.0.
 package protoyaml
 
 import (
@@ -14,6 +29,10 @@ var jsonpb = protojson.UnmarshalOptions{
 	DiscardUnknown: true,
 }
 
+// Unmarshal parses YAML bytes into a protobuf message.
+//
+// Deprecated: Use github.com/apstndb/protoyaml.Unmarshal instead. This package
+// is frozen for downstream compatibility and will be removed in v0.3.0.
 func Unmarshal(b []byte, result proto.Message) error {
 	j, err := YAMLToJSON(b)
 	if err != nil {
@@ -23,10 +42,20 @@ func Unmarshal(b []byte, result proto.Message) error {
 }
 
 // UnmarshalJSON unmarshals JSON bytes into a protobuf message with this package's decode options.
+//
+// Deprecated: Use github.com/apstndb/protoyaml.UnmarshalJSON instead. This
+// package is frozen for downstream compatibility and will be removed in v0.3.0.
 func UnmarshalJSON(j []byte, result proto.Message) error {
 	return jsonpb.Unmarshal(j, result)
 }
 
+// Marshal encodes a protobuf message as YAML using reflection-based encoding.
+//
+// Deprecated: The output format is an accident of reflection-based encoding, not
+// a designed artifact. This package is frozen for downstream compatibility
+// (spanner-mycli pins its exact output) and will be removed in v0.3.0. New code
+// should use github.com/apstndb/protoyaml.Marshal, which produces canonical
+// protojson-over-YAML output.
 func Marshal(m proto.Message, opts ...yaml.EncodeOption) ([]byte, error) {
 	opts = slices.Clone(opts)
 	opts = append(opts, yaml.UseJSONMarshaler())
@@ -34,6 +63,9 @@ func Marshal(m proto.Message, opts ...yaml.EncodeOption) ([]byte, error) {
 }
 
 // YAMLToJSON converts YAML bytes into JSON bytes for protojson.Unmarshal.
+//
+// Deprecated: Use github.com/apstndb/protoyaml.YAMLToJSON instead. This package
+// is frozen for downstream compatibility and will be removed in v0.3.0.
 func YAMLToJSON(y []byte) ([]byte, error) {
 	var i interface{}
 	err := yaml.Unmarshal(y, &i)


### PR DESCRIPTION
## Summary

Two related changes:

1. **Adopt the extracted module for the input path.** Switch `extract.go` and
   `extract_test.go` from the in-repo `github.com/apstndb/spannerplan/protoyaml`
   helper to the released module `github.com/apstndb/protoyaml` v0.1.0. The
   `YAMLToJSON`, `UnmarshalJSON`, and `Unmarshal` signatures are identical, so
   this is a **pure import swap with zero behavior change** — call sites are
   untouched and tests pass with no golden updates. No `replace` directive is
   used; the module is pulled from the proxy.

2. **Freeze the in-repo `protoyaml` package.** Add package-level and
   per-function `Deprecated:` documentation without changing any behavior. The
   package is retained only for downstream compatibility: spanner-mycli pins the
   exact bytes produced by `Marshal`. That output format was never a designed
   artifact but an accident of reflection-based encoding; new code should use
   the canonical protojson-over-YAML module. The package is slated for removal
   in **v0.3.0**, once spanner-mycli has migrated. The repo README mention is
   updated accordingly.

## Validation

- `go test ./...` — pass, **zero golden changes**
- `golangci-lint run ./...` — clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g