### PR TITLE
docs: refresh compatibility matrix (spannerplanviz v0.10.0, rs parity v0.2.1)

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -54,6 +54,6 @@ As of 2026-07-08:
 
 | Consumer | Validated against |
 |---|---|
-| spannerplanviz v0.9.3 | spannerplan v0.2.1 |
-| rendertree-web (rolling) | spannerplan v0.2.1, spannerplanviz v0.9.3 |
-| spannerplan-rs (main, post-v0.1.0-alpha.1) | spannerplan `cmd/rendertree` v0.2.0 (parity CI; v0.2.1 contains no rendering changes) |
+| spannerplanviz v0.10.0 | spannerplan v0.2.1 |
+| rendertree-web (rolling) | spannerplan v0.2.1, spannerplanviz v0.10.0 |
+| spannerplan-rs (main, post-v0.1.0-alpha.1) | spannerplan `cmd/rendertree` v0.2.1 (parity CI + weekly canary vs latest) |


### PR DESCRIPTION
Matrix follow-up for the v0.10.0 release and the spannerplan-rs parity pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g