### PR TITLE
docs: add ecosystem matrix and pinned-ref integrity check

### DIFF
--- a/.github/workflows/ecosystem-canary.yml
+++ b/.github/workflows/ecosystem-canary.yml
@@ -2,8 +2,8 @@ name: Ecosystem pinned-ref integrity
 
 # Non-blocking pinned-reference integrity check. Verifies ECOSYSTEM.md against
 # ecosystem/matrix.json on every run, and optionally fetches pinned public
-# consumer go.mod files to detect a moved/deleted ref, rewritten history, or
-# GitHub API reachability/content failure at the recorded pin.
+# consumer go.mod files to detect an unreachable recorded ref or dependency
+# content that no longer matches the recorded pin.
 #
 # This workflow never runs on push/pull_request as a required gate for the live
 # network check: live mode is schedule + workflow_dispatch only. Document drift
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
   issues: write
+
+concurrency:
+  group: ecosystem-pinned-ref-integrity
+  cancel-in-progress: false
 
 jobs:
   canary:
@@ -40,14 +44,14 @@ jobs:
           go run ./ecosystem/cmd/canary -live 2>&1 | tee canary-output.txt
 
       - name: Upload integrity-check output
-        if: failure()
+        if: ${{ always() && steps.integrity.outcome == 'failure' }}
         uses: actions/upload-artifact@v4
         with:
           name: ecosystem-pinned-ref-integrity-output
           path: canary-output.txt
 
       - name: Open or update integrity tracking issue
-        if: failure()
+        if: ${{ always() && steps.integrity.outcome == 'failure' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/ecosystem-canary.yml
+++ b/.github/workflows/ecosystem-canary.yml
@@ -1,0 +1,80 @@
+name: Ecosystem canary
+
+# Non-blocking governance check. Verifies ECOSYSTEM.md against
+# ecosystem/matrix.json on every run, and optionally fetches pinned public
+# consumer go.mod files to detect silent matrix drift.
+#
+# This workflow never runs on push/pull_request as a required gate for the live
+# network check: live mode is schedule + workflow_dispatch only. Document drift
+# is already covered by `go test ./ecosystem` in the main CI suite.
+on:
+  schedule:
+    # Mondays at 07:00 UTC (after spannerplan-rs parity canary).
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Check document drift and pinned public go.mod requires
+        id: canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go run ./ecosystem/cmd/canary -live 2>&1 | tee canary-output.txt
+
+      - name: Upload canary output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ecosystem-canary-output
+          path: canary-output.txt
+
+      - name: Open or update drift tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Ecosystem matrix drift against pinned public consumers"
+          body=$(cat <<EOF
+          The scheduled ecosystem canary failed: a pinned public consumer
+          \`go.mod\` no longer matches \`ecosystem/matrix.json\`, or
+          \`ECOSYSTEM.md\` drifted from the matrix.
+
+          Update \`ecosystem/matrix.json\` (and regenerate \`ECOSYSTEM.md\` with
+          \`go run ./ecosystem/cmd/render\`) after confirming the new pins. Do
+          not treat a changed module floor as a compatibility claim.
+
+          - Failing run: ${RUN_URL}
+          - Log artifact: \`ecosystem-canary-output\`
+
+          This issue is updated by the canary; a new comment is added on each
+          subsequent failure while it stays open.
+          EOF
+          )
+
+          existing=$(gh issue list \
+            --state open \
+            --search "\"${title}\" in:title" \
+            --json number,title \
+            --jq "map(select(.title == \"${title}\")) | .[0].number // empty")
+
+          if [ -n "${existing}" ]; then
+            echo "Updating existing issue #${existing}"
+            gh issue comment "${existing}" --body "${body}"
+          else
+            echo "Creating new drift issue"
+            gh issue create --title "${title}" --body "${body}"
+          fi

--- a/.github/workflows/ecosystem-canary.yml
+++ b/.github/workflows/ecosystem-canary.yml
@@ -1,12 +1,15 @@
-name: Ecosystem canary
+name: Ecosystem pinned-ref integrity
 
-# Non-blocking governance check. Verifies ECOSYSTEM.md against
+# Non-blocking pinned-reference integrity check. Verifies ECOSYSTEM.md against
 # ecosystem/matrix.json on every run, and optionally fetches pinned public
-# consumer go.mod files to detect silent matrix drift.
+# consumer go.mod files to detect a moved/deleted ref, rewritten history, or
+# GitHub API reachability/content failure at the recorded pin.
 #
 # This workflow never runs on push/pull_request as a required gate for the live
 # network check: live mode is schedule + workflow_dispatch only. Document drift
-# is already covered by `go test ./ecosystem` in the main CI suite.
+# is already covered by `go test ./ecosystem` in the main CI suite. It does not
+# resolve current downstream main/latest refs, so it is not a downstream-current
+# compatibility or freshness check.
 on:
   schedule:
     # Mondays at 07:00 UTC (after spannerplan-rs parity canary).
@@ -27,40 +30,45 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Check document drift and pinned public go.mod requires
-        id: canary
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: go run ./ecosystem/cmd/canary -live 2>&1 | tee canary-output.txt
+      - name: Check document and pinned public references
+        id: integrity
+        # An explicit bash shell enables pipefail, so a failed canary remains a
+        # failed step even though tee preserves the diagnostic output.
+        shell: bash
+        run: |
+          set -euo pipefail
+          go run ./ecosystem/cmd/canary -live 2>&1 | tee canary-output.txt
 
-      - name: Upload canary output
+      - name: Upload integrity-check output
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ecosystem-canary-output
+          name: ecosystem-pinned-ref-integrity-output
           path: canary-output.txt
 
-      - name: Open or update drift tracking issue
+      - name: Open or update integrity tracking issue
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          title="Ecosystem matrix drift against pinned public consumers"
+          title="Ecosystem pinned-ref integrity check failed"
           body=$(cat <<EOF
-          The scheduled ecosystem canary failed: a pinned public consumer
-          \`go.mod\` no longer matches \`ecosystem/matrix.json\`, or
-          \`ECOSYSTEM.md\` drifted from the matrix.
+          The scheduled ecosystem pinned-ref integrity check failed: a pinned
+          public consumer \`go.mod\` no longer matches \`ecosystem/matrix.json\`,
+          its recorded ref can no longer be read, or \`ECOSYSTEM.md\` drifted
+          from the matrix.
 
           Update \`ecosystem/matrix.json\` (and regenerate \`ECOSYSTEM.md\` with
-          \`go run ./ecosystem/cmd/render\`) after confirming the new pins. Do
-          not treat a changed module floor as a compatibility claim.
+          \`go run ./ecosystem/cmd/render\`) after confirming the recorded
+          pins. This integrity check does not resolve downstream \`main\` or
+          \`latest\` refs and does not make a compatibility claim.
 
           - Failing run: ${RUN_URL}
-          - Log artifact: \`ecosystem-canary-output\`
+          - Log artifact: \`ecosystem-pinned-ref-integrity-output\`
 
-          This issue is updated by the canary; a new comment is added on each
+          This issue is updated by the integrity checker; a new comment is added on each
           subsequent failure while it stays open.
           EOF
           )
@@ -75,6 +83,6 @@ jobs:
             echo "Updating existing issue #${existing}"
             gh issue comment "${existing}" --body "${body}"
           else
-            echo "Creating new drift issue"
+            echo "Creating new integrity issue"
             gh issue create --title "${title}" --body "${body}"
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Use Go 1.24 as in CI.
 - `make ecosystem-check`: verify `ECOSYSTEM.md` matches `ecosystem/matrix.json`.
 - `make ecosystem-render`: regenerate marked `ECOSYSTEM.md` tables from the matrix.
 - `make ecosystem-pinned-ref-integrity`: live integrity check of pinned public
-  consumer `go.mod` requires. This does not resolve current downstream refs.
+  consumer `go.mod` requires derived from observed matrix rows. This does not
+  resolve current downstream refs or attest commit identity.
 - `go run ./cmd/rendertree < plan.yaml`: render a query plan from YAML or JSON.
 - `go run ./cmd/lintplan < plan.yaml`: print heuristic warnings for expensive plan operators.
 - `golangci-lint run --timeout=5m`: run the same linter family used in GitHub Actions. Run lint before creating a commit, not just before opening a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ Use Go 1.24 as in CI.
 
 - `go test -v ./...`: run the full test suite across all packages.
 - `make test`: project shortcut for the same full test run.
+- `make ecosystem-check`: verify `ECOSYSTEM.md` matches `ecosystem/matrix.json`.
+- `make ecosystem-render`: regenerate marked `ECOSYSTEM.md` tables from the matrix.
+- `make ecosystem-canary`: live check of pinned public consumer `go.mod` requires.
 - `go run ./cmd/rendertree < plan.yaml`: render a query plan from YAML or JSON.
 - `go run ./cmd/lintplan < plan.yaml`: print heuristic warnings for expensive plan operators.
 - `golangci-lint run --timeout=5m`: run the same linter family used in GitHub Actions. Run lint before creating a commit, not just before opening a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Use Go 1.24 as in CI.
 - `make test`: project shortcut for the same full test run.
 - `make ecosystem-check`: verify `ECOSYSTEM.md` matches `ecosystem/matrix.json`.
 - `make ecosystem-render`: regenerate marked `ECOSYSTEM.md` tables from the matrix.
-- `make ecosystem-canary`: live check of pinned public consumer `go.mod` requires.
+- `make ecosystem-pinned-ref-integrity`: live integrity check of pinned public
+  consumer `go.mod` requires. This does not resolve current downstream refs.
 - `go run ./cmd/rendertree < plan.yaml`: render a query plan from YAML or JSON.
 - `go run ./cmd/lintplan < plan.yaml`: print heuristic warnings for expensive plan operators.
 - `golangci-lint run --timeout=5m`: run the same linter family used in GitHub Actions. Run lint before creating a commit, not just before opening a PR.

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -3,14 +3,22 @@
 This document defines how the repositories that render Google Cloud Spanner
 query plans relate to each other, and the rules that keep them consistent.
 
+Machine-readable source of truth for the role and observed-pin tables:
+[`ecosystem/matrix.json`](ecosystem/matrix.json). Regenerate the marked sections
+with `go run ./ecosystem/cmd/render`, and verify with
+`go test ./ecosystem` or `go run ./ecosystem/cmd/canary`.
+
 ## Repositories and roles
 
+<!-- ecosystem-roles:begin -->
 | Repo | Role |
 |---|---|
-| [spannerplan](https://github.com/apstndb/spannerplan) (Go) | Ecosystem semantic reference: plan parsing, tree building, text rendering. Golden-output generator for ports. Pure Go — no CGO/Rust/WASM requirements. |
+| [spannerplan](https://github.com/apstndb/spannerplan) (Go) | Ecosystem semantic reference: plan parsing, tree building, text rendering, and golden-output generation for ports. Pure Go — no CGO/Rust/WASM requirements. |
 | [spannerplan-rs](https://github.com/apstndb/spannerplan-rs) (Rust) | Distribution core for non-Go ecosystems (C FFI, browser WASM, GitHub-Release JS tarballs). Follows the Go reference via byte-for-byte parity tests and never forks rendering semantics; "canonical" claims in its docs are scoped to that repository's internals. |
-| [spannerplanviz](https://github.com/apstndb/spannerplanviz) (Go) | Diagram source generator (Mermaid source, and DOT source via the `dot` package) plus native Graphviz rasterization for CLI use. |
-| [rendertree-web](https://github.com/apstndb/rendertree-web) | Product UI (GitHub Pages). Thin composition layer over the libraries; bundle size and safe rendering of untrusted plans are first-class requirements. |
+| [spannerplanviz](https://github.com/apstndb/spannerplanviz) (Go) | Diagram source renderer (Mermaid, DOT via the `dot` package, and D2) plus native Graphviz rasterization for CLI use. |
+| [rendertree-web](https://github.com/apstndb/rendertree-web) (Go/WASM + TypeScript) | Lightweight public renderer/playground (GitHub Pages). Thin composition over the libraries; bundle size and safe rendering of untrusted plans are first-class requirements. |
+| spanner-plan-viewer (local unpublished) | Experimental interactive diagnostics workbench (local checkout only; no published GitHub remote). Not a product dependency of this release train and not a canary target. |
+<!-- ecosystem-roles:end -->
 
 ## Design principle
 
@@ -18,6 +26,11 @@ Rendering pipelines produce text (ASCII table, Mermaid source, DOT source).
 Rasterization happens at the edge: natively in CLIs, and in the browser via
 JS/WASM renderers (the mermaid npm package, @hpcc-js/wasm-graphviz). Do not
 embed a Graphviz runtime into WASM binaries.
+
+`rendertree-web` is the lightweight public renderer/playground. The local
+unpublished `spanner-plan-viewer` checkout is an experimental diagnostics
+workbench: useful for interactive analysis, but not a published product
+dependency of this release train and not part of the public canary set.
 
 ## Governance
 
@@ -43,25 +56,47 @@ embed a Graphviz runtime into WASM binaries.
   downstream pins and golden suites (spanner-mycli — the direct API
   downstream; rendertree-web; spannerplan-rs). cloudspannerecosystem/spanner-cli
   has its own renderer and does not consume spannerplan; treat it as an
-  output-semantics comparator, not a release blocker.
+  output-semantics comparator, not a release blocker. Do not block releases
+  on the local unpublished viewer.
 - Dependency minimums: modules consumed as libraries (spannerplan,
   spannerplanviz) keep their go.mod dependency floors low for MVS
   friendliness — bumping a library's minimums raises the floor for every
-  downstream. Dependency and security updates happen in applications
-  (rendertree-web, spanner-mycli). Do not raise library minimums except when
-  new code requires it.
+  downstream. A declared `go.mod` require is a module floor, not proof that a
+  newer library tag was validated. Dependency and security updates happen in
+  applications (rendertree-web, spanner-mycli). Do not raise library minimums
+  except when new code requires it.
 - YAML handling: the Go repositories standardize on goccy/go-yaml, accessed
   through [apstndb/protoyaml](https://github.com/apstndb/protoyaml) — a
   general-purpose canonical protojson⇄YAML utility that originated in this
   ecosystem but is versioned and governed independently (it is not part of
   this release train).
+- Matrix drift control: `ecosystem/matrix.json` owns the observed pins. CI
+  fails if `ECOSYSTEM.md` marked tables diverge. The public downstream canary
+  (`.github/workflows/ecosystem-canary.yml`) checks only explicit pinned refs
+  for public repositories and never depends on the local viewer.
 
 ## Compatibility matrix
 
-As of 2026-07-08:
+<!-- ecosystem-matrix:begin -->
+As of 2026-07-18:
 
-| Consumer | Validated against |
-|---|---|
-| spannerplanviz v0.10.0 | spannerplan v0.2.1 |
-| rendertree-web (rolling) | spannerplan v0.2.1, spannerplanviz v0.10.0 |
-| spannerplan-rs (main, post-v0.1.0-alpha.1) | spannerplan `cmd/rendertree` v0.2.1 (parity CI + weekly canary vs latest) |
+Rows record observed pins and declared module floors only. A go.mod require is not a compatibility or validation claim unless an entry explicitly says so.
+
+spannerplan tags observed while writing this matrix: stable v0.2.1; prerelease v0.3.0-alpha.1.
+
+| Consumer | Observed ref | Declared / recorded pins |
+|---|---|---|
+| spannerplanviz | `v0.10.2` | `github.com/apstndb/spannerplan v0.2.0` |
+| rendertree-web | `2f260a07666b589422fafac870a050e177c02b33` | `github.com/apstndb/spannerplan v0.2.1`; `github.com/apstndb/spannerplanviz v0.10.2` |
+| spanner-mycli | `v0.33.0` | `github.com/apstndb/spannerplan v0.2.0` |
+| spanner-mycli | `b43f857b194751e2631073bab45ff2026e86e30c` | `github.com/apstndb/spannerplan v0.2.1` |
+| spannerplan-rs | `main` | parity CI `github.com/apstndb/spannerplan/cmd/rendertree@v0.3.0-alpha.1`; fixtures synced at `v0.2.1`; latest published `v0.1.0-alpha.2` |
+<!-- ecosystem-matrix:end -->
+
+When updating pins, edit `ecosystem/matrix.json` first, then run
+`go run ./ecosystem/cmd/render`. Optional live verification against the pinned
+public refs:
+
+```bash
+go run ./ecosystem/cmd/canary -live
+```

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -74,8 +74,9 @@ dependency of this release train and not part of the public canary set.
   fails if `ECOSYSTEM.md` marked tables diverge. The public pinned-ref integrity
   checker (`.github/workflows/ecosystem-canary.yml`) reads only explicit pinned
   refs for public repositories and never depends on the local viewer. It can
-  detect a moved/deleted pin, rewritten history, or API/content failure at that
-  pin; it does not resolve downstream `main` or `latest` refs.
+  detect an unreachable recorded ref or dependency content that no longer
+  matches the recorded pin; it does not resolve downstream `main` or `latest`
+  refs and does not attest the ref's commit identity.
 
 ## Compatibility matrix
 

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -71,9 +71,11 @@ dependency of this release train and not part of the public canary set.
   ecosystem but is versioned and governed independently (it is not part of
   this release train).
 - Matrix drift control: `ecosystem/matrix.json` owns the observed pins. CI
-  fails if `ECOSYSTEM.md` marked tables diverge. The public downstream canary
-  (`.github/workflows/ecosystem-canary.yml`) checks only explicit pinned refs
-  for public repositories and never depends on the local viewer.
+  fails if `ECOSYSTEM.md` marked tables diverge. The public pinned-ref integrity
+  checker (`.github/workflows/ecosystem-canary.yml`) reads only explicit pinned
+  refs for public repositories and never depends on the local viewer. It can
+  detect a moved/deleted pin, rewritten history, or API/content failure at that
+  pin; it does not resolve downstream `main` or `latest` refs.
 
 ## Compatibility matrix
 
@@ -82,7 +84,9 @@ As of 2026-07-18:
 
 Rows record observed pins and declared module floors only. A go.mod require is not a compatibility or validation claim unless an entry explicitly says so.
 
-spannerplan tags observed while writing this matrix: stable v0.2.1; prerelease v0.3.0-alpha.1.
+spannerplan tags observed while writing this matrix: latest non-prerelease v0.2.1; prerelease v0.3.0-alpha.1.
+
+These are v0 releases and do not imply a stable compatibility contract.
 
 | Consumer | Observed ref | Declared / recorded pins |
 |---|---|---|
@@ -90,12 +94,13 @@ spannerplan tags observed while writing this matrix: stable v0.2.1; prerelease v
 | rendertree-web | `2f260a07666b589422fafac870a050e177c02b33` | `github.com/apstndb/spannerplan v0.2.1`; `github.com/apstndb/spannerplanviz v0.10.2` |
 | spanner-mycli | `v0.33.0` | `github.com/apstndb/spannerplan v0.2.0` |
 | spanner-mycli | `b43f857b194751e2631073bab45ff2026e86e30c` | `github.com/apstndb/spannerplan v0.2.1` |
-| spannerplan-rs | `main` | parity CI `github.com/apstndb/spannerplan/cmd/rendertree@v0.3.0-alpha.1`; fixtures synced at `v0.2.1`; latest published `v0.1.0-alpha.2` |
+| spannerplan-rs | `main` | parity CI `github.com/apstndb/spannerplan/cmd/rendertree@v0.3.0-alpha.1`; fixtures synced at `v0.2.1`; latest published `v0.1.0-alpha.3` |
 <!-- ecosystem-matrix:end -->
 
 When updating pins, edit `ecosystem/matrix.json` first, then run
 `go run ./ecosystem/cmd/render`. Optional live verification against the pinned
-public refs:
+public refs. This is a pinned-ref integrity check, not a lookup of current
+downstream `main` or `latest` refs:
 
 ```bash
 go run ./ecosystem/cmd/canary -live

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test ecosystem-check ecosystem-render ecosystem-canary
+.PHONY: test ecosystem-check ecosystem-render ecosystem-pinned-ref-integrity
 
 test:
 	go test -v ./...
@@ -10,5 +10,5 @@ ecosystem-check:
 ecosystem-render:
 	go run ./ecosystem/cmd/render
 
-ecosystem-canary:
+ecosystem-pinned-ref-integrity:
 	go run ./ecosystem/cmd/canary -live

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-.PHONY: test
+.PHONY: test ecosystem-check ecosystem-render ecosystem-canary
 
 test:
 	go test -v ./...
+
+ecosystem-check:
+	go test -v ./ecosystem
+	go run ./ecosystem/cmd/canary
+
+ecosystem-render:
+	go run ./ecosystem/cmd/render
+
+ecosystem-canary:
+	go run ./ecosystem/cmd/canary -live

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Spanner QueryPlan manipulation module.
 
 This is a v0 module, so breaking changes are possible across all packages before v1.
 
-See [ECOSYSTEM.md](ECOSYSTEM.md) for how this module relates to spannerplan-rs, spannerplanviz, and rendertree-web.
+See [ECOSYSTEM.md](ECOSYSTEM.md) and [`ecosystem/matrix.json`](ecosystem/matrix.json)
+for how this module relates to spannerplan-rs, spannerplanviz, rendertree-web,
+and the local unpublished diagnostics viewer.
 
 ## Directory overview
 

--- a/ecosystem/check.go
+++ b/ecosystem/check.go
@@ -20,7 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -32,6 +34,8 @@ const (
 	matrixJSON  = "matrix.json"
 	ecosystemMD = "ECOSYSTEM.md"
 )
+
+var githubRepoPattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})/[A-Za-z0-9][A-Za-z0-9._-]*$`)
 
 // Matrix is the machine-readable source of truth for ECOSYSTEM.md tables.
 type Matrix struct {
@@ -146,8 +150,21 @@ func (m *Matrix) validate() error {
 			continue
 		}
 		canaryCount++
+		if o.Kind != "go_module_require" {
+			return fmt.Errorf("observed[%d]: canary kind must be go_module_require", i)
+		}
 		if o.Repo == "" || o.Path == "" {
 			return fmt.Errorf("observed[%d]: canary repo and path are required", i)
+		}
+		if !githubRepoPattern.MatchString(o.Repo) {
+			return fmt.Errorf("observed[%d]: canary repo must be a URL-safe OWNER/REPO", i)
+		}
+		_, repoName, _ := strings.Cut(o.Repo, "/")
+		if repoName != o.Consumer {
+			return fmt.Errorf("observed[%d]: canary repo name %q must match consumer %q", i, repoName, o.Consumer)
+		}
+		if err := validateCanaryPath(o.Path); err != nil {
+			return fmt.Errorf("observed[%d]: canary path: %w", i, err)
 		}
 		if len(o.Requires) == 0 {
 			return fmt.Errorf("observed[%d]: canary requires must not be empty", i)
@@ -155,6 +172,24 @@ func (m *Matrix) validate() error {
 	}
 	if canaryCount == 0 {
 		return fmt.Errorf("observed must contain at least one canary entry")
+	}
+	return nil
+}
+
+func validateCanaryPath(filePath string) error {
+	if filePath == "" || path.IsAbs(filePath) {
+		return fmt.Errorf("must be a non-empty relative path")
+	}
+	if strings.Contains(filePath, `\`) {
+		return fmt.Errorf("must use forward slashes")
+	}
+	if path.Clean(filePath) != filePath {
+		return fmt.Errorf("must be clean and must not contain traversal segments")
+	}
+	for _, segment := range strings.Split(filePath, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return fmt.Errorf("must not contain empty or traversal segments")
+		}
 	}
 	return nil
 }

--- a/ecosystem/check.go
+++ b/ecosystem/check.go
@@ -1,0 +1,302 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ecosystem keeps ECOSYSTEM.md aligned with a machine-readable matrix.
+package ecosystem
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	rolesBegin  = "<!-- ecosystem-roles:begin -->"
+	rolesEnd    = "<!-- ecosystem-roles:end -->"
+	matrixBegin = "<!-- ecosystem-matrix:begin -->"
+	matrixEnd   = "<!-- ecosystem-matrix:end -->"
+	matrixJSON  = "matrix.json"
+	ecosystemMD = "ECOSYSTEM.md"
+)
+
+// Matrix is the machine-readable source of truth for ECOSYSTEM.md tables.
+type Matrix struct {
+	AsOf                string            `json:"as_of"`
+	Disclaimer          string            `json:"disclaimer"`
+	Roles               []Role            `json:"roles"`
+	SpannerplanVersions map[string]string `json:"spannerplan_versions"`
+	Observed            []Observed        `json:"observed"`
+	CanaryTargets       []CanaryTarget    `json:"canary_targets"`
+}
+
+// Role describes one ecosystem participant.
+type Role struct {
+	ID       string  `json:"id"`
+	Repo     *string `json:"repo"`
+	Language string  `json:"language"`
+	Role     string  `json:"role"`
+}
+
+// Observed records an observed pin without implying compatibility.
+type Observed struct {
+	Consumer               string          `json:"consumer"`
+	ConsumerRef            string          `json:"consumer_ref"`
+	Kind                   string          `json:"kind"`
+	Canary                 *bool           `json:"canary,omitempty"`
+	Requires               []ModuleRequire `json:"requires,omitempty"`
+	ParityGoInstall        string          `json:"parity_go_install,omitempty"`
+	FixtureSyncRef         string          `json:"fixture_sync_ref,omitempty"`
+	LatestPublishedRelease string          `json:"latest_published_release,omitempty"`
+	Notes                  string          `json:"notes,omitempty"`
+}
+
+// ModuleRequire is a declared Go module require.
+type ModuleRequire struct {
+	Module  string `json:"module"`
+	Version string `json:"version"`
+}
+
+// CanaryTarget is a public pinned ref checked by the live canary.
+type CanaryTarget struct {
+	Repo          string            `json:"repo"`
+	Ref           string            `json:"ref"`
+	Path          string            `json:"path"`
+	ExpectRequire map[string]string `json:"expect_require"`
+}
+
+// LoadMatrix reads ecosystem/matrix.json from dir (repository root or ecosystem/).
+func LoadMatrix(dir string) (*Matrix, error) {
+	path, err := resolveMatrixPath(dir)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m Matrix
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&m); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	if err := m.validate(); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func resolveMatrixPath(dir string) (string, error) {
+	candidates := []string{
+		filepath.Join(dir, matrixJSON),
+		filepath.Join(dir, "ecosystem", matrixJSON),
+	}
+	for _, c := range candidates {
+		if st, err := os.Stat(c); err == nil && !st.IsDir() {
+			return c, nil
+		}
+	}
+	return "", fmt.Errorf("matrix.json not found under %s", dir)
+}
+
+func (m *Matrix) validate() error {
+	if m.AsOf == "" {
+		return fmt.Errorf("as_of is required")
+	}
+	if len(m.Roles) == 0 {
+		return fmt.Errorf("roles must not be empty")
+	}
+	if len(m.Observed) == 0 {
+		return fmt.Errorf("observed must not be empty")
+	}
+	if len(m.CanaryTargets) == 0 {
+		return fmt.Errorf("canary_targets must not be empty")
+	}
+	for i, t := range m.CanaryTargets {
+		if t.Repo == "" || t.Ref == "" || t.Path == "" {
+			return fmt.Errorf("canary_targets[%d]: repo, ref, and path are required", i)
+		}
+		if len(t.ExpectRequire) == 0 {
+			return fmt.Errorf("canary_targets[%d]: expect_require must not be empty", i)
+		}
+	}
+	return nil
+}
+
+// RenderRolesTable renders the markdown roles table body (with header).
+func (m *Matrix) RenderRolesTable() string {
+	var b strings.Builder
+	b.WriteString("| Repo | Role |\n")
+	b.WriteString("|---|---|\n")
+	for _, r := range m.Roles {
+		name := r.ID
+		left := name
+		if r.Repo != nil && *r.Repo != "" {
+			left = fmt.Sprintf("[%s](%s)", name, *r.Repo)
+		}
+		if r.Language != "" {
+			left = fmt.Sprintf("%s (%s)", left, r.Language)
+		}
+		b.WriteString("| ")
+		b.WriteString(left)
+		b.WriteString(" | ")
+		b.WriteString(r.Role)
+		b.WriteString(" |\n")
+	}
+	return b.String()
+}
+
+// RenderObservedTable renders the observed-pins markdown table.
+func (m *Matrix) RenderObservedTable() string {
+	var b strings.Builder
+	b.WriteString("As of ")
+	b.WriteString(m.AsOf)
+	b.WriteString(":\n\n")
+	if m.Disclaimer != "" {
+		b.WriteString(m.Disclaimer)
+		b.WriteString("\n\n")
+	}
+	if len(m.SpannerplanVersions) > 0 {
+		b.WriteString("spannerplan tags observed while writing this matrix: ")
+		parts := make([]string, 0, len(m.SpannerplanVersions))
+		if v, ok := m.SpannerplanVersions["latest_stable"]; ok {
+			parts = append(parts, "stable "+v)
+		}
+		if v, ok := m.SpannerplanVersions["latest_prerelease"]; ok {
+			parts = append(parts, "prerelease "+v)
+		}
+		b.WriteString(strings.Join(parts, "; "))
+		b.WriteString(".\n\n")
+	}
+	b.WriteString("| Consumer | Observed ref | Declared / recorded pins |\n")
+	b.WriteString("|---|---|---|\n")
+	for _, o := range m.Observed {
+		pins := formatObservedPins(o)
+		b.WriteString("| ")
+		b.WriteString(o.Consumer)
+		b.WriteString(" | `")
+		b.WriteString(o.ConsumerRef)
+		b.WriteString("` | ")
+		b.WriteString(pins)
+		b.WriteString(" |\n")
+	}
+	return b.String()
+}
+
+func formatObservedPins(o Observed) string {
+	var parts []string
+	for _, req := range o.Requires {
+		parts = append(parts, fmt.Sprintf("`%s %s`", req.Module, req.Version))
+	}
+	if o.ParityGoInstall != "" {
+		parts = append(parts, "parity CI `"+o.ParityGoInstall+"`")
+	}
+	if o.FixtureSyncRef != "" {
+		parts = append(parts, "fixtures synced at `"+o.FixtureSyncRef+"`")
+	}
+	if o.LatestPublishedRelease != "" {
+		parts = append(parts, "latest published `"+o.LatestPublishedRelease+"`")
+	}
+	if len(parts) == 0 {
+		return "_(see notes in matrix.json)_"
+	}
+	return strings.Join(parts, "; ")
+}
+
+// CheckDocument verifies ECOSYSTEM.md marked sections match matrix.json.
+func CheckDocument(repoRoot string) error {
+	m, err := LoadMatrix(filepath.Join(repoRoot, "ecosystem"))
+	if err != nil {
+		return err
+	}
+	docPath := filepath.Join(repoRoot, ecosystemMD)
+	doc, err := os.ReadFile(docPath)
+	if err != nil {
+		return err
+	}
+	if err := checkSection(string(doc), rolesBegin, rolesEnd, m.RenderRolesTable()); err != nil {
+		return fmt.Errorf("%s roles section: %w", ecosystemMD, err)
+	}
+	if err := checkSection(string(doc), matrixBegin, matrixEnd, m.RenderObservedTable()); err != nil {
+		return fmt.Errorf("%s matrix section: %w", ecosystemMD, err)
+	}
+	return nil
+}
+
+func checkSection(doc, begin, end, want string) error {
+	start := strings.Index(doc, begin)
+	if start < 0 {
+		return fmt.Errorf("missing begin marker %q", begin)
+	}
+	rest := doc[start+len(begin):]
+	stopRel := strings.Index(rest, end)
+	if stopRel < 0 {
+		return fmt.Errorf("missing end marker %q", end)
+	}
+	got := strings.TrimSpace(rest[:stopRel])
+	want = strings.TrimSpace(want)
+	if got != want {
+		return fmt.Errorf("drift detected; regenerate with `go run ./ecosystem/cmd/render`\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+	return nil
+}
+
+// WriteDocumentSections rewrites the marked sections in ECOSYSTEM.md from matrix.json.
+func WriteDocumentSections(repoRoot string) error {
+	m, err := LoadMatrix(filepath.Join(repoRoot, "ecosystem"))
+	if err != nil {
+		return err
+	}
+	docPath := filepath.Join(repoRoot, ecosystemMD)
+	doc, err := os.ReadFile(docPath)
+	if err != nil {
+		return err
+	}
+	updated, err := replaceSection(string(doc), rolesBegin, rolesEnd, "\n"+m.RenderRolesTable())
+	if err != nil {
+		return err
+	}
+	updated, err = replaceSection(updated, matrixBegin, matrixEnd, "\n"+m.RenderObservedTable())
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(docPath, []byte(updated), 0o644)
+}
+
+func replaceSection(doc, begin, end, body string) (string, error) {
+	start := strings.Index(doc, begin)
+	if start < 0 {
+		return "", fmt.Errorf("missing begin marker %q", begin)
+	}
+	afterBegin := start + len(begin)
+	stop := strings.Index(doc[afterBegin:], end)
+	if stop < 0 {
+		return "", fmt.Errorf("missing end marker %q", end)
+	}
+	stopAbs := afterBegin + stop
+	var b strings.Builder
+	b.WriteString(doc[:afterBegin])
+	if !strings.HasPrefix(body, "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteString(body)
+	if !strings.HasSuffix(body, "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteString(doc[stopAbs:])
+	return b.String(), nil
+}

--- a/ecosystem/check.go
+++ b/ecosystem/check.go
@@ -40,7 +40,6 @@ type Matrix struct {
 	Roles               []Role            `json:"roles"`
 	SpannerplanVersions map[string]string `json:"spannerplan_versions"`
 	Observed            []Observed        `json:"observed"`
-	CanaryTargets       []CanaryTarget    `json:"canary_targets"`
 }
 
 // Role describes one ecosystem participant.
@@ -56,7 +55,9 @@ type Observed struct {
 	Consumer               string          `json:"consumer"`
 	ConsumerRef            string          `json:"consumer_ref"`
 	Kind                   string          `json:"kind"`
-	Canary                 *bool           `json:"canary,omitempty"`
+	Canary                 bool            `json:"canary,omitempty"`
+	Repo                   string          `json:"repo,omitempty"`
+	Path                   string          `json:"path,omitempty"`
 	Requires               []ModuleRequire `json:"requires,omitempty"`
 	ParityGoInstall        string          `json:"parity_go_install,omitempty"`
 	FixtureSyncRef         string          `json:"fixture_sync_ref,omitempty"`
@@ -72,10 +73,10 @@ type ModuleRequire struct {
 
 // CanaryTarget is a public pinned ref checked by the live canary.
 type CanaryTarget struct {
-	Repo          string            `json:"repo"`
-	Ref           string            `json:"ref"`
-	Path          string            `json:"path"`
-	ExpectRequire map[string]string `json:"expect_require"`
+	Repo          string
+	Ref           string
+	Path          string
+	ExpectRequire map[string]string
 }
 
 // LoadMatrix reads ecosystem/matrix.json from dir (repository root or ecosystem/).
@@ -123,18 +124,61 @@ func (m *Matrix) validate() error {
 	if len(m.Observed) == 0 {
 		return fmt.Errorf("observed must not be empty")
 	}
-	if len(m.CanaryTargets) == 0 {
-		return fmt.Errorf("canary_targets must not be empty")
+	canaryCount := 0
+	for i, o := range m.Observed {
+		if o.Consumer == "" || o.ConsumerRef == "" || o.Kind == "" {
+			return fmt.Errorf("observed[%d]: consumer, consumer_ref, and kind are required", i)
+		}
+		seenRequires := make(map[string]struct{}, len(o.Requires))
+		for j, req := range o.Requires {
+			if req.Module == "" || req.Version == "" {
+				return fmt.Errorf("observed[%d].requires[%d]: module and version are required", i, j)
+			}
+			if _, ok := seenRequires[req.Module]; ok {
+				return fmt.Errorf("observed[%d]: duplicate require %q", i, req.Module)
+			}
+			seenRequires[req.Module] = struct{}{}
+		}
+		if !o.Canary {
+			if o.Repo != "" || o.Path != "" {
+				return fmt.Errorf("observed[%d]: repo and path require canary=true", i)
+			}
+			continue
+		}
+		canaryCount++
+		if o.Repo == "" || o.Path == "" {
+			return fmt.Errorf("observed[%d]: canary repo and path are required", i)
+		}
+		if len(o.Requires) == 0 {
+			return fmt.Errorf("observed[%d]: canary requires must not be empty", i)
+		}
 	}
-	for i, t := range m.CanaryTargets {
-		if t.Repo == "" || t.Ref == "" || t.Path == "" {
-			return fmt.Errorf("canary_targets[%d]: repo, ref, and path are required", i)
-		}
-		if len(t.ExpectRequire) == 0 {
-			return fmt.Errorf("canary_targets[%d]: expect_require must not be empty", i)
-		}
+	if canaryCount == 0 {
+		return fmt.Errorf("observed must contain at least one canary entry")
 	}
 	return nil
+}
+
+// CanaryTargets derives the live integrity checks from the observed rows. This
+// keeps the rendered matrix and the network check on one source of truth.
+func (m *Matrix) CanaryTargets() []CanaryTarget {
+	targets := make([]CanaryTarget, 0)
+	for _, o := range m.Observed {
+		if !o.Canary {
+			continue
+		}
+		requires := make(map[string]string, len(o.Requires))
+		for _, req := range o.Requires {
+			requires[req.Module] = req.Version
+		}
+		targets = append(targets, CanaryTarget{
+			Repo:          o.Repo,
+			Ref:           o.ConsumerRef,
+			Path:          o.Path,
+			ExpectRequire: requires,
+		})
+	}
+	return targets
 }
 
 // RenderRolesTable renders the markdown roles table body (with header).

--- a/ecosystem/check.go
+++ b/ecosystem/check.go
@@ -173,14 +173,15 @@ func (m *Matrix) RenderObservedTable() string {
 	if len(m.SpannerplanVersions) > 0 {
 		b.WriteString("spannerplan tags observed while writing this matrix: ")
 		parts := make([]string, 0, len(m.SpannerplanVersions))
-		if v, ok := m.SpannerplanVersions["latest_stable"]; ok {
-			parts = append(parts, "stable "+v)
+		if v, ok := m.SpannerplanVersions["latest_non_prerelease"]; ok {
+			parts = append(parts, "latest non-prerelease "+v)
 		}
 		if v, ok := m.SpannerplanVersions["latest_prerelease"]; ok {
 			parts = append(parts, "prerelease "+v)
 		}
 		b.WriteString(strings.Join(parts, "; "))
 		b.WriteString(".\n\n")
+		b.WriteString("These are v0 releases and do not imply a stable compatibility contract.\n\n")
 	}
 	b.WriteString("| Consumer | Observed ref | Declared / recorded pins |\n")
 	b.WriteString("|---|---|---|\n")

--- a/ecosystem/check_test.go
+++ b/ecosystem/check_test.go
@@ -53,13 +53,43 @@ func TestMatrixLoadsAndValidates(t *testing.T) {
 	if !foundViewer {
 		t.Fatal("expected spanner-plan-viewer role")
 	}
-	if len(m.CanaryTargets) == 0 {
+	targets := m.CanaryTargets()
+	if len(targets) == 0 {
 		t.Fatal("expected canary targets")
 	}
-	for _, c := range m.CanaryTargets {
+	for _, c := range targets {
 		if c.Repo == "" || c.Ref == "" {
 			t.Fatalf("canary target missing repo/ref: %+v", c)
 		}
+	}
+}
+
+func TestCanaryTargetsAreDerivedFromObservedRows(t *testing.T) {
+	m, err := ecosystem.LoadMatrix(filepath.Join(repoRoot(t), "ecosystem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets := m.CanaryTargets()
+	if len(targets) != 3 {
+		t.Fatalf("CanaryTargets() count = %d, want 3", len(targets))
+	}
+	if got := targets[0].ExpectRequire["github.com/apstndb/spannerplan"]; got != "v0.2.0" {
+		t.Fatalf("first target spannerplan require = %q, want v0.2.0", got)
+	}
+}
+
+func TestMatrixRejectsIncompleteCanaryObservedRow(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "ecosystem", "matrix.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	broken := strings.Replace(string(raw), `"repo": "apstndb/spannerplanviz"`, `"repo": ""`, 1)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "matrix.json"), []byte(broken), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ecosystem.LoadMatrix(dir); err == nil || !strings.Contains(err.Error(), "canary repo and path are required") {
+		t.Fatalf("LoadMatrix() error = %v, want incomplete canary error", err)
 	}
 }
 
@@ -77,6 +107,10 @@ func TestCanaryWorkflowUsesPipefail(t *testing.T) {
 	const want = "shell: bash\n        run: |\n          set -euo pipefail\n          go run ./ecosystem/cmd/canary -live 2>&1 | tee canary-output.txt"
 	if !strings.Contains(string(workflow), want) {
 		t.Fatalf("ecosystem canary must use explicit bash with pipefail before tee: %q", want)
+	}
+	const outcomeGate = `if: ${{ always() && steps.integrity.outcome == 'failure' }}`
+	if got := strings.Count(string(workflow), outcomeGate); got != 2 {
+		t.Fatalf("integrity-step outcome gate count = %d, want 2", got)
 	}
 }
 

--- a/ecosystem/check_test.go
+++ b/ecosystem/check_test.go
@@ -93,6 +93,73 @@ func TestMatrixRejectsIncompleteCanaryObservedRow(t *testing.T) {
 	}
 }
 
+func TestMatrixRejectsUnsafeCanaryCoordinates(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "ecosystem", "matrix.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		old     string
+		new     string
+		wantErr string
+	}{
+		{
+			name:    "malformed repo",
+			old:     `"repo": "apstndb/spannerplanviz"`,
+			new:     `"repo": "apstndb/spannerplanviz/extra"`,
+			wantErr: "canary repo must be a URL-safe OWNER/REPO",
+		},
+		{
+			name:    "mismatched consumer repo",
+			old:     `"repo": "apstndb/spannerplanviz"`,
+			new:     `"repo": "apstndb/another-repo"`,
+			wantErr: "must match consumer",
+		},
+		{
+			name:    "absolute path",
+			old:     `"path": "go.mod"`,
+			new:     `"path": "/go.mod"`,
+			wantErr: "must be a non-empty relative path",
+		},
+		{
+			name:    "traversal path",
+			old:     `"path": "go.mod"`,
+			new:     `"path": "dir/../go.mod"`,
+			wantErr: "must be clean and must not contain traversal segments",
+		},
+		{
+			name:    "backslash path",
+			old:     `"path": "go.mod"`,
+			new:     `"path": "dir\\\\go.mod"`,
+			wantErr: "must use forward slashes",
+		},
+		{
+			name:    "wrong canary kind",
+			old:     `"kind": "go_module_require"`,
+			new:     `"kind": "parity_workflow_pin"`,
+			wantErr: "canary kind must be go_module_require",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			broken := strings.Replace(string(raw), tt.old, tt.new, 1)
+			if broken == string(raw) {
+				t.Fatalf("test replacement did not match %q", tt.old)
+			}
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "matrix.json"), []byte(broken), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ecosystem.LoadMatrix(dir); err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("LoadMatrix() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestECOSYSTEMMarkdownMatchesMatrix(t *testing.T) {
 	if err := ecosystem.CheckDocument(repoRoot(t)); err != nil {
 		t.Fatal(err)

--- a/ecosystem/check_test.go
+++ b/ecosystem/check_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/apstndb/spannerplan/ecosystem"
@@ -65,6 +66,17 @@ func TestMatrixLoadsAndValidates(t *testing.T) {
 func TestECOSYSTEMMarkdownMatchesMatrix(t *testing.T) {
 	if err := ecosystem.CheckDocument(repoRoot(t)); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCanaryWorkflowUsesPipefail(t *testing.T) {
+	workflow, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "workflows", "ecosystem-canary.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "shell: bash\n        run: |\n          set -euo pipefail\n          go run ./ecosystem/cmd/canary -live 2>&1 | tee canary-output.txt"
+	if !strings.Contains(string(workflow), want) {
+		t.Fatalf("ecosystem canary must use explicit bash with pipefail before tee: %q", want)
 	}
 }
 

--- a/ecosystem/check_test.go
+++ b/ecosystem/check_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecosystem_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/apstndb/spannerplan/ecosystem"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), ".."))
+}
+
+func TestMatrixLoadsAndValidates(t *testing.T) {
+	m, err := ecosystem.LoadMatrix(filepath.Join(repoRoot(t), "ecosystem"))
+	if err != nil {
+		t.Fatalf("LoadMatrix: %v", err)
+	}
+	if m.AsOf == "" {
+		t.Fatal("as_of empty")
+	}
+	foundViewer := false
+	for _, r := range m.Roles {
+		if r.ID == "spanner-plan-viewer" {
+			foundViewer = true
+			if r.Repo != nil {
+				t.Fatalf("viewer must remain unpublished (repo=%v)", *r.Repo)
+			}
+		}
+	}
+	if !foundViewer {
+		t.Fatal("expected spanner-plan-viewer role")
+	}
+	if len(m.CanaryTargets) == 0 {
+		t.Fatal("expected canary targets")
+	}
+	for _, c := range m.CanaryTargets {
+		if c.Repo == "" || c.Ref == "" {
+			t.Fatalf("canary target missing repo/ref: %+v", c)
+		}
+	}
+}
+
+func TestECOSYSTEMMarkdownMatchesMatrix(t *testing.T) {
+	if err := ecosystem.CheckDocument(repoRoot(t)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRenderRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	ecoDir := filepath.Join(root, "ecosystem")
+	if err := os.MkdirAll(ecoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srcMatrix, err := os.ReadFile(filepath.Join(repoRoot(t), "ecosystem", "matrix.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ecoDir, "matrix.json"), srcMatrix, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	doc := `# title
+
+## Roles
+
+<!-- ecosystem-roles:begin -->
+old roles
+<!-- ecosystem-roles:end -->
+
+## Matrix
+
+<!-- ecosystem-matrix:begin -->
+old matrix
+<!-- ecosystem-matrix:end -->
+`
+	if err := os.WriteFile(filepath.Join(root, "ECOSYSTEM.md"), []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ecosystem.WriteDocumentSections(root); err != nil {
+		t.Fatalf("WriteDocumentSections: %v", err)
+	}
+	if err := ecosystem.CheckDocument(root); err != nil {
+		t.Fatalf("CheckDocument after write: %v", err)
+	}
+}

--- a/ecosystem/cmd/canary/main.go
+++ b/ecosystem/cmd/canary/main.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Command canary checks public consumer go.mod pins against ecosystem/matrix.json.
+// Command canary checks the integrity of public consumer go.mod pins recorded
+// in ecosystem/matrix.json.
 //
 // It is intentionally offline unless -live is set. Live mode fetches only the
 // pinned public refs listed under canary_targets and never touches local-only
-// viewers.
+// viewers. It does not resolve current downstream branch or release refs.
 package main
 
 import (
@@ -37,7 +38,7 @@ import (
 )
 
 func main() {
-	live := flag.Bool("live", false, "fetch pinned public go.mod files and compare requires")
+	live := flag.Bool("live", false, "fetch pinned public go.mod files and verify recorded requires")
 	root := flag.String("root", "", "repository root (default: cwd)")
 	flag.Parse()
 
@@ -59,7 +60,7 @@ func main() {
 	fmt.Println("ECOSYSTEM.md matches ecosystem/matrix.json")
 
 	if !*live {
-		fmt.Println("skipping live canary (pass -live)")
+		fmt.Println("skipping live pinned-ref integrity check (pass -live)")
 		return
 	}
 
@@ -175,6 +176,6 @@ func truncate(s string, n int) string {
 }
 
 func fail(err error) {
-	fmt.Fprintf(os.Stderr, "ecosystem canary: %v\n", err)
+	fmt.Fprintf(os.Stderr, "ecosystem pinned-ref integrity check: %v\n", err)
 	os.Exit(1)
 }

--- a/ecosystem/cmd/canary/main.go
+++ b/ecosystem/cmd/canary/main.go
@@ -101,9 +101,11 @@ func checkTarget(client *http.Client, t ecosystem.CanaryTarget) error {
 	return nil
 }
 
-func fetchGitHubFile(client *http.Client, repo, ref, path string) ([]byte, error) {
-	u := fmt.Sprintf("https://api.github.com/repos/%s/contents/%s?ref=%s",
-		repo, path, url.QueryEscape(ref))
+func fetchGitHubFile(client *http.Client, repo, ref, filePath string) ([]byte, error) {
+	u, err := githubContentsURL(repo, ref, filePath)
+	if err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
@@ -135,6 +137,22 @@ func fetchGitHubFile(client *http.Client, repo, ref, path string) ([]byte, error
 		return nil, fmt.Errorf("unexpected encoding %q", payload.Encoding)
 	}
 	return base64.StdEncoding.DecodeString(strings.ReplaceAll(payload.Content, "\n", ""))
+}
+
+func githubContentsURL(repo, ref, filePath string) (string, error) {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return "", fmt.Errorf("invalid GitHub repository %q", repo)
+	}
+	u := &url.URL{
+		Scheme: "https",
+		Host:   "api.github.com",
+		Path:   "/repos/" + owner + "/" + name + "/contents/" + filePath,
+	}
+	query := u.Query()
+	query.Set("ref", ref)
+	u.RawQuery = query.Encode()
+	return u.String(), nil
 }
 
 var requireLine = regexp.MustCompile(`^\s*([^\s]+)\s+(v[^\s]+)`)

--- a/ecosystem/cmd/canary/main.go
+++ b/ecosystem/cmd/canary/main.go
@@ -16,8 +16,8 @@
 // in ecosystem/matrix.json.
 //
 // It is intentionally offline unless -live is set. Live mode fetches only the
-// pinned public refs listed under canary_targets and never touches local-only
-// viewers. It does not resolve current downstream branch or release refs.
+// observed rows marked canary=true and never touches local-only viewers. It
+// does not resolve current downstream branch or release refs.
 package main
 
 import (
@@ -70,7 +70,7 @@ func main() {
 	}
 	client := &http.Client{Timeout: 30 * time.Second}
 	var failed int
-	for _, t := range m.CanaryTargets {
+	for _, t := range m.CanaryTargets() {
 		if err := checkTarget(client, t); err != nil {
 			fmt.Fprintf(os.Stderr, "FAIL %s@%s: %v\n", t.Repo, t.Ref, err)
 			failed++

--- a/ecosystem/cmd/canary/main.go
+++ b/ecosystem/cmd/canary/main.go
@@ -1,0 +1,180 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command canary checks public consumer go.mod pins against ecosystem/matrix.json.
+//
+// It is intentionally offline unless -live is set. Live mode fetches only the
+// pinned public refs listed under canary_targets and never touches local-only
+// viewers.
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/apstndb/spannerplan/ecosystem"
+)
+
+func main() {
+	live := flag.Bool("live", false, "fetch pinned public go.mod files and compare requires")
+	root := flag.String("root", "", "repository root (default: cwd)")
+	flag.Parse()
+
+	repoRoot := *root
+	if repoRoot == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			fail(err)
+		}
+		repoRoot = wd
+	}
+	if filepath.Base(repoRoot) == "ecosystem" {
+		repoRoot = filepath.Dir(repoRoot)
+	}
+
+	if err := ecosystem.CheckDocument(repoRoot); err != nil {
+		fail(err)
+	}
+	fmt.Println("ECOSYSTEM.md matches ecosystem/matrix.json")
+
+	if !*live {
+		fmt.Println("skipping live canary (pass -live)")
+		return
+	}
+
+	m, err := ecosystem.LoadMatrix(filepath.Join(repoRoot, "ecosystem"))
+	if err != nil {
+		fail(err)
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	var failed int
+	for _, t := range m.CanaryTargets {
+		if err := checkTarget(client, t); err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL %s@%s: %v\n", t.Repo, t.Ref, err)
+			failed++
+			continue
+		}
+		fmt.Printf("ok %s@%s\n", t.Repo, t.Ref)
+	}
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func checkTarget(client *http.Client, t ecosystem.CanaryTarget) error {
+	raw, err := fetchGitHubFile(client, t.Repo, t.Ref, t.Path)
+	if err != nil {
+		return err
+	}
+	requires := parseGoModRequires(string(raw))
+	for mod, want := range t.ExpectRequire {
+		got, ok := requires[mod]
+		if !ok {
+			return fmt.Errorf("missing require %s (want %s)", mod, want)
+		}
+		if got != want {
+			return fmt.Errorf("%s: got %s, want %s", mod, got, want)
+		}
+	}
+	return nil
+}
+
+func fetchGitHubFile(client *http.Client, repo, ref, path string) ([]byte, error) {
+	u := fmt.Sprintf("https://api.github.com/repos/%s/contents/%s?ref=%s",
+		repo, path, url.QueryEscape(ref))
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github API %s: %s", resp.Status, truncate(string(body), 200))
+	}
+	var payload struct {
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	if payload.Encoding != "base64" {
+		return nil, fmt.Errorf("unexpected encoding %q", payload.Encoding)
+	}
+	return base64.StdEncoding.DecodeString(strings.ReplaceAll(payload.Content, "\n", ""))
+}
+
+var requireLine = regexp.MustCompile(`^\s*([^\s]+)\s+(v[^\s]+)`)
+
+func parseGoModRequires(src string) map[string]string {
+	out := make(map[string]string)
+	inBlock := false
+	for _, line := range strings.Split(src, "\n") {
+		trim := strings.TrimSpace(line)
+		if strings.HasPrefix(trim, "require (") {
+			inBlock = true
+			continue
+		}
+		if inBlock {
+			if trim == ")" {
+				inBlock = false
+				continue
+			}
+			if m := requireLine.FindStringSubmatch(trim); m != nil {
+				out[m[1]] = m[2]
+			}
+			continue
+		}
+		if strings.HasPrefix(trim, "require ") {
+			rest := strings.TrimSpace(strings.TrimPrefix(trim, "require "))
+			if m := requireLine.FindStringSubmatch(rest); m != nil {
+				out[m[1]] = m[2]
+			}
+		}
+	}
+	return out
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+func fail(err error) {
+	fmt.Fprintf(os.Stderr, "ecosystem canary: %v\n", err)
+	os.Exit(1)
+}

--- a/ecosystem/cmd/canary/main_test.go
+++ b/ecosystem/cmd/canary/main_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestGitHubContentsURLKeepsRefInQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		wantPath string
+	}{
+		{name: "fragment delimiter", filePath: "dir/go.mod#snapshot", wantPath: "/repos/apstndb/spannerplanviz/contents/dir/go.mod#snapshot"},
+		{name: "query delimiter", filePath: "dir/go.mod?snapshot", wantPath: "/repos/apstndb/spannerplanviz/contents/dir/go.mod?snapshot"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := githubContentsURL("apstndb/spannerplanviz", "v0.10.2#fixed", tt.filePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			u, err := url.Parse(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if u.Path != tt.wantPath {
+				t.Fatalf("Path = %q, want %q (URL %q)", u.Path, tt.wantPath, got)
+			}
+			if u.Fragment != "" {
+				t.Fatalf("Fragment = %q, want empty (URL %q)", u.Fragment, got)
+			}
+			if gotRef := u.Query().Get("ref"); gotRef != "v0.10.2#fixed" {
+				t.Fatalf("ref = %q, want exact ref (URL %q)", gotRef, got)
+			}
+			if strings.Contains(got, tt.filePath) {
+				t.Fatalf("URL contains unescaped path delimiter %q: %q", tt.filePath, got)
+			}
+		})
+	}
+}
+
+func TestGitHubContentsURLRejectsMalformedRepo(t *testing.T) {
+	for _, repo := range []string{"", "apstndb", "apstndb/repo/extra"} {
+		if _, err := githubContentsURL(repo, "main", "go.mod"); err == nil {
+			t.Fatalf("githubContentsURL(%q) unexpectedly succeeded", repo)
+		}
+	}
+}

--- a/ecosystem/cmd/render/main.go
+++ b/ecosystem/cmd/render/main.go
@@ -1,0 +1,47 @@
+// Copyright 2026 apstndb
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command render rewrites ECOSYSTEM.md marked sections from ecosystem/matrix.json.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/apstndb/spannerplan/ecosystem"
+)
+
+func main() {
+	root, err := os.Getwd()
+	if err != nil {
+		fail(err)
+	}
+	// Allow running from repo root or ecosystem/.
+	if filepath.Base(root) == "ecosystem" {
+		root = filepath.Dir(root)
+	}
+	if len(os.Args) > 1 {
+		root = os.Args[1]
+	}
+	if err := ecosystem.WriteDocumentSections(root); err != nil {
+		fail(err)
+	}
+	fmt.Println("updated ECOSYSTEM.md from ecosystem/matrix.json")
+}
+
+func fail(err error) {
+	fmt.Fprintf(os.Stderr, "ecosystem render: %v\n", err)
+	os.Exit(1)
+}

--- a/ecosystem/matrix.json
+++ b/ecosystem/matrix.json
@@ -34,7 +34,7 @@
     }
   ],
   "spannerplan_versions": {
-    "latest_stable": "v0.2.1",
+    "latest_non_prerelease": "v0.2.1",
     "latest_prerelease": "v0.3.0-alpha.1"
   },
   "observed": [
@@ -97,8 +97,8 @@
       "kind": "parity_workflow_pin",
       "parity_go_install": "github.com/apstndb/spannerplan/cmd/rendertree@v0.3.0-alpha.1",
       "fixture_sync_ref": "v0.2.1",
-      "latest_published_release": "v0.1.0-alpha.2",
-      "notes": "Required CI installs rendertree@v0.3.0-alpha.1. Fixture copies under testdata/ were last synced at spannerplan v0.2.1. Workspace docs may mention unpublished v0.1.0-alpha.3; do not treat that as a published release. Weekly canary vs spannerplan@latest lives in spannerplan-rs and is non-blocking."
+      "latest_published_release": "v0.1.0-alpha.3",
+      "notes": "Required CI installs rendertree@v0.3.0-alpha.1. Fixture copies under testdata/ were last synced at spannerplan v0.2.1. Weekly canary vs spannerplan@latest lives in spannerplan-rs and is non-blocking."
     }
   ],
   "canary_targets": [

--- a/ecosystem/matrix.json
+++ b/ecosystem/matrix.json
@@ -1,0 +1,131 @@
+{
+  "as_of": "2026-07-18",
+  "disclaimer": "Rows record observed pins and declared module floors only. A go.mod require is not a compatibility or validation claim unless an entry explicitly says so.",
+  "roles": [
+    {
+      "id": "spannerplan",
+      "repo": "https://github.com/apstndb/spannerplan",
+      "language": "Go",
+      "role": "Ecosystem semantic reference: plan parsing, tree building, text rendering, and golden-output generation for ports. Pure Go — no CGO/Rust/WASM requirements."
+    },
+    {
+      "id": "spannerplan-rs",
+      "repo": "https://github.com/apstndb/spannerplan-rs",
+      "language": "Rust",
+      "role": "Distribution core for non-Go ecosystems (C FFI, browser WASM, GitHub-Release JS tarballs). Follows the Go reference via byte-for-byte parity tests and never forks rendering semantics; \"canonical\" claims in its docs are scoped to that repository's internals."
+    },
+    {
+      "id": "spannerplanviz",
+      "repo": "https://github.com/apstndb/spannerplanviz",
+      "language": "Go",
+      "role": "Diagram source renderer (Mermaid, DOT via the `dot` package, and D2) plus native Graphviz rasterization for CLI use."
+    },
+    {
+      "id": "rendertree-web",
+      "repo": "https://github.com/apstndb/rendertree-web",
+      "language": "Go/WASM + TypeScript",
+      "role": "Lightweight public renderer/playground (GitHub Pages). Thin composition over the libraries; bundle size and safe rendering of untrusted plans are first-class requirements."
+    },
+    {
+      "id": "spanner-plan-viewer",
+      "repo": null,
+      "language": "local unpublished",
+      "role": "Experimental interactive diagnostics workbench (local checkout only; no published GitHub remote). Not a product dependency of this release train and not a canary target."
+    }
+  ],
+  "spannerplan_versions": {
+    "latest_stable": "v0.2.1",
+    "latest_prerelease": "v0.3.0-alpha.1"
+  },
+  "observed": [
+    {
+      "consumer": "spannerplanviz",
+      "consumer_ref": "v0.10.2",
+      "kind": "go_module_require",
+      "requires": [
+        {
+          "module": "github.com/apstndb/spannerplan",
+          "version": "v0.2.0"
+        }
+      ],
+      "notes": "Latest published release is v0.10.2. Declared module floor is spannerplan v0.2.0; this is not a claim that v0.10.2 was validated against spannerplan v0.2.1."
+    },
+    {
+      "consumer": "rendertree-web",
+      "consumer_ref": "2f260a07666b589422fafac870a050e177c02b33",
+      "kind": "go_module_require",
+      "requires": [
+        {
+          "module": "github.com/apstndb/spannerplan",
+          "version": "v0.2.1"
+        },
+        {
+          "module": "github.com/apstndb/spannerplanviz",
+          "version": "v0.10.2"
+        }
+      ],
+      "notes": "Rolling main tip observed on 2026-07-18; no release tag used."
+    },
+    {
+      "consumer": "spanner-mycli",
+      "consumer_ref": "v0.33.0",
+      "kind": "go_module_require",
+      "requires": [
+        {
+          "module": "github.com/apstndb/spannerplan",
+          "version": "v0.2.0"
+        }
+      ],
+      "notes": "Latest published release pin. main@b43f857b194751e2631073bab45ff2026e86e30c currently requires spannerplan v0.2.1; that tip is recorded separately below and is not treated as the release canary pin."
+    },
+    {
+      "consumer": "spanner-mycli",
+      "consumer_ref": "b43f857b194751e2631073bab45ff2026e86e30c",
+      "kind": "go_module_require",
+      "canary": false,
+      "requires": [
+        {
+          "module": "github.com/apstndb/spannerplan",
+          "version": "v0.2.1"
+        }
+      ],
+      "notes": "Observed main tip on 2026-07-18. Informational only; canary uses the published v0.33.0 pin."
+    },
+    {
+      "consumer": "spannerplan-rs",
+      "consumer_ref": "main",
+      "kind": "parity_workflow_pin",
+      "parity_go_install": "github.com/apstndb/spannerplan/cmd/rendertree@v0.3.0-alpha.1",
+      "fixture_sync_ref": "v0.2.1",
+      "latest_published_release": "v0.1.0-alpha.2",
+      "notes": "Required CI installs rendertree@v0.3.0-alpha.1. Fixture copies under testdata/ were last synced at spannerplan v0.2.1. Workspace docs may mention unpublished v0.1.0-alpha.3; do not treat that as a published release. Weekly canary vs spannerplan@latest lives in spannerplan-rs and is non-blocking."
+    }
+  ],
+  "canary_targets": [
+    {
+      "repo": "apstndb/spannerplanviz",
+      "ref": "v0.10.2",
+      "path": "go.mod",
+      "expect_require": {
+        "github.com/apstndb/spannerplan": "v0.2.0"
+      }
+    },
+    {
+      "repo": "apstndb/rendertree-web",
+      "ref": "2f260a07666b589422fafac870a050e177c02b33",
+      "path": "go.mod",
+      "expect_require": {
+        "github.com/apstndb/spannerplan": "v0.2.1",
+        "github.com/apstndb/spannerplanviz": "v0.10.2"
+      }
+    },
+    {
+      "repo": "apstndb/spanner-mycli",
+      "ref": "v0.33.0",
+      "path": "go.mod",
+      "expect_require": {
+        "github.com/apstndb/spannerplan": "v0.2.0"
+      }
+    }
+  ]
+}

--- a/ecosystem/matrix.json
+++ b/ecosystem/matrix.json
@@ -42,6 +42,9 @@
       "consumer": "spannerplanviz",
       "consumer_ref": "v0.10.2",
       "kind": "go_module_require",
+      "canary": true,
+      "repo": "apstndb/spannerplanviz",
+      "path": "go.mod",
       "requires": [
         {
           "module": "github.com/apstndb/spannerplan",
@@ -54,6 +57,9 @@
       "consumer": "rendertree-web",
       "consumer_ref": "2f260a07666b589422fafac870a050e177c02b33",
       "kind": "go_module_require",
+      "canary": true,
+      "repo": "apstndb/rendertree-web",
+      "path": "go.mod",
       "requires": [
         {
           "module": "github.com/apstndb/spannerplan",
@@ -70,6 +76,9 @@
       "consumer": "spanner-mycli",
       "consumer_ref": "v0.33.0",
       "kind": "go_module_require",
+      "canary": true,
+      "repo": "apstndb/spanner-mycli",
+      "path": "go.mod",
       "requires": [
         {
           "module": "github.com/apstndb/spannerplan",
@@ -82,7 +91,6 @@
       "consumer": "spanner-mycli",
       "consumer_ref": "b43f857b194751e2631073bab45ff2026e86e30c",
       "kind": "go_module_require",
-      "canary": false,
       "requires": [
         {
           "module": "github.com/apstndb/spannerplan",
@@ -99,33 +107,6 @@
       "fixture_sync_ref": "v0.2.1",
       "latest_published_release": "v0.1.0-alpha.3",
       "notes": "Required CI installs rendertree@v0.3.0-alpha.1. Fixture copies under testdata/ were last synced at spannerplan v0.2.1. Weekly canary vs spannerplan@latest lives in spannerplan-rs and is non-blocking."
-    }
-  ],
-  "canary_targets": [
-    {
-      "repo": "apstndb/spannerplanviz",
-      "ref": "v0.10.2",
-      "path": "go.mod",
-      "expect_require": {
-        "github.com/apstndb/spannerplan": "v0.2.0"
-      }
-    },
-    {
-      "repo": "apstndb/rendertree-web",
-      "ref": "2f260a07666b589422fafac870a050e177c02b33",
-      "path": "go.mod",
-      "expect_require": {
-        "github.com/apstndb/spannerplan": "v0.2.1",
-        "github.com/apstndb/spannerplanviz": "v0.10.2"
-      }
-    },
-    {
-      "repo": "apstndb/spanner-mycli",
-      "ref": "v0.33.0",
-      "path": "go.mod",
-      "expect_require": {
-        "github.com/apstndb/spannerplan": "v0.2.0"
-      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Refresh `ECOSYSTEM.md` roles: `spannerplan` semantic reference, `spannerplanviz` diagram renderer, `rendertree-web` lightweight public renderer/playground, and local unpublished `spanner-plan-viewer` as an experimental diagnostics workbench (not a published product dependency or integrity-check target).
- Replace ambiguous "validated against" and "stable v0" wording with observed pins, declared module floors, latest non-prerelease, and explicit v0 instability.
- Make `ecosystem/matrix.json` the source of truth for marked documentation tables and derive live targets directly from observed rows instead of duplicating target data.
- Add offline document-drift and canary-derivation tests plus a scheduled/manual pinned-ref integrity check for the recorded public `spannerplanviz`, `rendertree-web`, and `spanner-mycli` refs.
- Propagate live-check failures through `tee` with explicit Bash/pipefail and open or update a tracking issue on failure.
- Gate reporting on the integrity step itself, so checkout/setup failures are not mislabeled as pin failures.
- Record the published `spannerplan-rs v0.1.0-alpha.3` release.

The live check intentionally verifies only recorded pinned refs. It detects an unreachable ref or dependency content that no longer matches the recorded pin; it does not attest commit identity, resolve current downstream `main`/`latest` refs, or make a compatibility claim.

## Test plan

- [x] `go test -v ./ecosystem`
- [x] `go test -v ./...`
- [x] `go run ./ecosystem/cmd/canary`
- [x] `go run ./ecosystem/cmd/canary -live`
- [x] pipefail regression and direct shell failure-propagation check
- [ ] Confirm CI green on the final head
- [ ] Manually dispatch **Ecosystem pinned-ref integrity** once after merge

Independent from structural-signature work.
