### PR TITLE
docs: record spannerplan alpha.2

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -85,7 +85,7 @@ As of 2026-07-18:
 
 Rows record observed pins and declared module floors only. A go.mod require is not a compatibility or validation claim unless an entry explicitly says so.
 
-spannerplan tags observed while writing this matrix: latest non-prerelease v0.2.1; prerelease v0.3.0-alpha.1.
+spannerplan tags observed while writing this matrix: latest non-prerelease v0.2.1; prerelease v0.3.0-alpha.2.
 
 These are v0 releases and do not imply a stable compatibility contract.
 

--- a/ecosystem/matrix.json
+++ b/ecosystem/matrix.json
@@ -35,7 +35,7 @@
   ],
   "spannerplan_versions": {
     "latest_non_prerelease": "v0.2.1",
-    "latest_prerelease": "v0.3.0-alpha.1"
+    "latest_prerelease": "v0.3.0-alpha.2"
   },
   "observed": [
     {


### PR DESCRIPTION
## Summary

- Records the published `v0.3.0-alpha.2` as the latest spannerplan prerelease in `ecosystem/matrix.json`.
- Regenerates the corresponding `ECOSYSTEM.md` table text.
- Leaves observed downstream dependency pins unchanged; this is release inventory, not a compatibility claim.

## Validation

- `go run ./ecosystem/cmd/render`
- `go test ./ecosystem/...`
- `git diff --check`
