### PR TITLE
Record Rust signature parity and local TUI

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -18,6 +18,7 @@ with `go run ./ecosystem/cmd/render`, and verify with
 | [spannerplanviz](https://github.com/apstndb/spannerplanviz) (Go) | Diagram source renderer (Mermaid, DOT via the `dot` package, and D2) plus native Graphviz rasterization for CLI use. |
 | [rendertree-web](https://github.com/apstndb/rendertree-web) (Go/WASM + TypeScript) | Lightweight public renderer/playground (GitHub Pages). Thin composition over the libraries; bundle size and safe rendering of untrusted plans are first-class requirements. |
 | spanner-plan-viewer (local unpublished) | Experimental interactive diagnostics workbench (local checkout only; no published GitHub remote). Not a product dependency of this release train and not a canary target. |
+| spanner-plan-viewer-tui (Go / Bubble Tea; local unpublished) | Sister terminal viewer over the Go reference Plantree semantics. Its outline uses occurrence identity and its explicit export uses the reference text renderer; it has no published GitHub remote and is not a canary target. |
 <!-- ecosystem-roles:end -->
 
 ## Design principle
@@ -31,6 +32,9 @@ embed a Graphviz runtime into WASM binaries.
 unpublished `spanner-plan-viewer` checkout is an experimental diagnostics
 workbench: useful for interactive analysis, but not a published product
 dependency of this release train and not part of the public canary set.
+The local unpublished `spanner-plan-viewer-tui` is its terminal-focused sister
+interface over the Go reference Plantree semantics. It is recorded for
+responsibility and pin visibility only; it likewise has no public canary.
 
 ## Governance
 
@@ -57,7 +61,7 @@ dependency of this release train and not part of the public canary set.
   downstream; rendertree-web; spannerplan-rs). cloudspannerecosystem/spanner-cli
   has its own renderer and does not consume spannerplan; treat it as an
   output-semantics comparator, not a release blocker. Do not block releases
-  on the local unpublished viewer.
+  on the local unpublished viewers.
 - Dependency minimums: modules consumed as libraries (spannerplan,
   spannerplanviz) keep their go.mod dependency floors low for MVS
   friendliness — bumping a library's minimums raises the floor for every
@@ -73,7 +77,7 @@ dependency of this release train and not part of the public canary set.
 - Matrix drift control: `ecosystem/matrix.json` owns the observed pins. CI
   fails if `ECOSYSTEM.md` marked tables diverge. The public pinned-ref integrity
   checker (`.github/workflows/ecosystem-canary.yml`) reads only explicit pinned
-  refs for public repositories and never depends on the local viewer. It can
+  refs for public repositories and never depends on the local viewers. It can
   detect an unreachable recorded ref or dependency content that no longer
   matches the recorded pin; it does not resolve downstream `main` or `latest`
   refs and does not attest the ref's commit identity.
@@ -95,7 +99,8 @@ These are v0 releases and do not imply a stable compatibility contract.
 | rendertree-web | `2f260a07666b589422fafac870a050e177c02b33` | `github.com/apstndb/spannerplan v0.2.1`; `github.com/apstndb/spannerplanviz v0.10.2` |
 | spanner-mycli | `v0.33.0` | `github.com/apstndb/spannerplan v0.2.0` |
 | spanner-mycli | `b43f857b194751e2631073bab45ff2026e86e30c` | `github.com/apstndb/spannerplan v0.2.1` |
-| spannerplan-rs | `main` | parity CI `github.com/apstndb/spannerplan/cmd/rendertree@v0.3.0-alpha.1`; fixtures synced at `v0.2.1`; latest published `v0.1.0-alpha.3` |
+| spannerplan-rs | `7793f4c02ec01282e4af9a2f86ee878dc6b3b77b` | parity CI `github.com/apstndb/spannerplan/cmd/rendertree@v0.3.0-alpha.2`; fixtures synced at `v0.2.1`; latest published `v0.1.0-alpha.3` |
+| spanner-plan-viewer-tui | `f9dcc6914a923e385c29be75970c7c580896c0f0` | `github.com/apstndb/spannerplan v0.3.0-alpha.2` |
 <!-- ecosystem-matrix:end -->
 
 When updating pins, edit `ecosystem/matrix.json` first, then run

--- a/ecosystem/check_test.go
+++ b/ecosystem/check_test.go
@@ -41,17 +41,22 @@ func TestMatrixLoadsAndValidates(t *testing.T) {
 	if m.AsOf == "" {
 		t.Fatal("as_of empty")
 	}
-	foundViewer := false
+	unpublishedViewers := map[string]bool{
+		"spanner-plan-viewer":     false,
+		"spanner-plan-viewer-tui": false,
+	}
 	for _, r := range m.Roles {
-		if r.ID == "spanner-plan-viewer" {
-			foundViewer = true
+		if _, ok := unpublishedViewers[r.ID]; ok {
+			unpublishedViewers[r.ID] = true
 			if r.Repo != nil {
-				t.Fatalf("viewer must remain unpublished (repo=%v)", *r.Repo)
+				t.Fatalf("%s must remain unpublished (repo=%v)", r.ID, *r.Repo)
 			}
 		}
 	}
-	if !foundViewer {
-		t.Fatal("expected spanner-plan-viewer role")
+	for id, found := range unpublishedViewers {
+		if !found {
+			t.Fatalf("expected %s role", id)
+		}
 	}
 	targets := m.CanaryTargets()
 	if len(targets) == 0 {

--- a/ecosystem/matrix.json
+++ b/ecosystem/matrix.json
@@ -31,6 +31,12 @@
       "repo": null,
       "language": "local unpublished",
       "role": "Experimental interactive diagnostics workbench (local checkout only; no published GitHub remote). Not a product dependency of this release train and not a canary target."
+    },
+    {
+      "id": "spanner-plan-viewer-tui",
+      "repo": null,
+      "language": "Go / Bubble Tea; local unpublished",
+      "role": "Sister terminal viewer over the Go reference Plantree semantics. Its outline uses occurrence identity and its explicit export uses the reference text renderer; it has no published GitHub remote and is not a canary target."
     }
   ],
   "spannerplan_versions": {
@@ -101,12 +107,24 @@
     },
     {
       "consumer": "spannerplan-rs",
-      "consumer_ref": "main",
+      "consumer_ref": "7793f4c02ec01282e4af9a2f86ee878dc6b3b77b",
       "kind": "parity_workflow_pin",
-      "parity_go_install": "github.com/apstndb/spannerplan/cmd/rendertree@v0.3.0-alpha.1",
+      "parity_go_install": "github.com/apstndb/spannerplan/cmd/rendertree@v0.3.0-alpha.2",
       "fixture_sync_ref": "v0.2.1",
       "latest_published_release": "v0.1.0-alpha.3",
-      "notes": "Required CI installs rendertree@v0.3.0-alpha.1. Fixture copies under testdata/ were last synced at spannerplan v0.2.1. Weekly canary vs spannerplan@latest lives in spannerplan-rs and is non-blocking."
+      "notes": "Observed main merge snapshot on 2026-07-18. Required CI installs rendertree@v0.3.0-alpha.2 and the Rust core carries structural-signature v1alpha1 byte parity with the copied Go alpha.2 golden. General reference fixture copies under testdata/ were last synced at spannerplan v0.2.1. Latest published distribution remains v0.1.0-alpha.3 because this main-only train added no WASM, FFI, or JavaScript surface. Weekly canary vs spannerplan@latest lives in spannerplan-rs and is non-blocking."
+    },
+    {
+      "consumer": "spanner-plan-viewer-tui",
+      "consumer_ref": "f9dcc6914a923e385c29be75970c7c580896c0f0",
+      "kind": "local_go_module_require",
+      "requires": [
+        {
+          "module": "github.com/apstndb/spannerplan",
+          "version": "v0.3.0-alpha.2"
+        }
+      ],
+      "notes": "Local unpublished snapshot observed on 2026-07-18. Informational only: there is no public repository or canary ref, and the TUI is outside this public release train."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- record the merged Rust structural-signature parity snapshot and Go alpha.2 CI pin
- keep the latest published Rust distribution at alpha.3 because this train added no WASM, FFI, or JavaScript surface
- add the local unpublished TUI as a separate ecosystem role and informational alpha.2 dependency row
- verify that both local viewers remain outside public canaries and release blocking

## Validation

- `go test ./...`
- `go run ./ecosystem/cmd/canary`
- `go run ./ecosystem/cmd/canary -live`
- generated `ECOSYSTEM.md` matches `ecosystem/matrix.json`

All versions remain v0/prerelease surfaces; this update does not claim stable or v1 compatibility.
